### PR TITLE
Add "Compact Session": summarize a session into a continuation prompt for a fresh tab

### DIFF
--- a/Kingdom_of_Claudes_Beloved_MDs/COMPACT_SESSION.md
+++ b/Kingdom_of_Claudes_Beloved_MDs/COMPACT_SESSION.md
@@ -1,0 +1,100 @@
+# Compact Session
+
+## What It Does & Why
+
+"Compact Session" turns a long, token-heavy conversation into a fresh, low-token
+one without losing context. On demand it reads the current session, asks a model
+to summarize it into a single self-contained continuation prompt, copies that
+prompt to the clipboard, and opens a brand-new tab with the prompt pre-filled in
+the input box (not auto-sent). The user reviews it and presses Enter to continue
+the same task in a new session that starts with a tiny context footprint.
+
+This is distinct from the CLI's in-place `/compact` (see `claudeMirror.compact`),
+which compresses the running context window but keeps the same session. Compact
+Session instead produces a portable prompt and starts a new session.
+
+## End-to-End Flow
+
+```
+InputArea "Compact" button
+  -> postMessage { type: 'compactSession' }
+  -> MessageHandler / CodexMessageHandler
+       -> vscode.commands.executeCommand('claudeMirror.compactSession', { sourceTabId })
+  -> commands.ts runCompactSession()
+       -> TabManager.compactSession({ sourceTabId })
+            -> sourceTab.collectHandoffSnapshot()            (full transcript via ConversationReader)
+            -> CompactSessionService.build(snapshot)         (AI summary, heuristic fallback)
+            -> vscode.env.clipboard.writeText(prompt)         (clipboard backup)
+            -> createTabForProvider(provider)                 (fresh tab, same provider)
+            -> targetTab.setForkInit({ promptText: prompt, messages: [] })
+            -> targetTab.startSession({ cwd })                (posts forkInit -> input pre-filled)
+            -> sourceTab.postMessage({ type: 'compactSessionResult', ... })
+  -> useClaudeStream 'compactSessionResult' -> clears button spinner + shows notice toast
+```
+
+## Key Files
+
+| File | Role |
+|------|------|
+| `src/extension/session/CompactSessionService.ts` | Builds the compact prompt: transcript + grounding capsule -> Claude CLI summary, with deterministic fallback. |
+| `src/extension/session/TabManager.ts` | `compactSession()` orchestrates snapshot -> build -> clipboard -> new tab -> result. Reuses `handoffLocks`. |
+| `src/extension/commands.ts` | `runCompactSession()` + command `claudeMirror.compactSession`. |
+| `src/extension/webview/MessageHandler.ts` | Claude `compactSession` case -> forwards to the command; posts failure result on reject. |
+| `src/extension/webview/CodexMessageHandler.ts` | Codex `compactSession` case (same forwarding). |
+| `src/extension/session/handoff/HandoffContextBuilder.ts` | Reused to build the structured grounding capsule (files, blockers, cwd/branch). |
+| `src/extension/session/handoff/HandoffPromptComposer.ts` | Reused as the deterministic fallback prompt. |
+| `src/webview/components/InputArea/InputArea.tsx` | The `.compact-session-button` (in `.clear-stack`), `handleCompactSession`, and the result toast. |
+| `src/webview/hooks/useClaudeStream.ts` | Handles `compactSessionResult` (clears spinner, sets notice). |
+| `src/webview/state/store.ts` | `compactingSession` + `compactSessionNotice` state. |
+| `src/webview/styles/global.css` | `.compact-session-button` styling + `compact-spin` keyframes. |
+| `src/webview/components/Help/helpContent.ts` | Bilingual Help entry `inputarea-compact-session`. |
+
+## CompactSessionService
+
+`build(snapshot, { claudeConfigDir? })` -> `{ prompt, source: 'ai' | 'heuristic' }`.
+
+1. Builds a `HandoffCapsule` via `HandoffContextBuilder` with a large turn budget
+   (60 turns, 1600 chars/turn) — used both for grounding the AI prompt and as the
+   fallback (`HandoffPromptComposer.compose`).
+2. Builds a plain-text transcript from `snapshot.messages` (USER/ASSISTANT lines;
+   `tool_use` blocks reduced to `[used tool: X]`). Truncated to
+   `MAX_TRANSCRIPT_CHARS` (24k) keeping head 35% + tail.
+3. Sends an instruction prompt to the Claude CLI (`claude -p --model <model>`)
+   asking for ONE self-contained handoff prompt organized into 7 sections
+   (objective, progress, current state, decisions, environment/files, blockers,
+   next steps), in the user's language, output-only.
+4. On empty transcript / spawn error / non-zero exit / timeout (90s) it returns
+   the deterministic heuristic prompt instead, so the feature never dead-ends.
+
+Model resolution: `claudeMirror.compactSession.model` if set, else
+`claudeMirror.analysisModel` (Haiku by default).
+
+## Configuration
+
+| Setting | Default | Purpose |
+|---------|---------|---------|
+| `claudeMirror.compactSession.model` | `""` | Model for the summary. Empty = reuse `claudeMirror.analysisModel`. Set a Sonnet id for higher quality. |
+
+## Message Contract
+
+- Webview -> Extension: `CompactSessionRequest` `{ type: 'compactSession' }`.
+- Extension -> Webview: `CompactSessionResultMessage`
+  `{ type: 'compactSessionResult', success, error?, promptChars?, openedNewTab?, copiedToClipboard?, source? }`.
+
+## UI
+
+- Button lives in `.clear-stack` next to Search and Clear, above the input box.
+- Shows a spinning icon while working; disabled when disconnected, during a
+  handoff lock, or while already compacting.
+- A transient toast (reusing `git-push-toast` styling) reports success/failure
+  and auto-dismisses after 6s. A 120s client-side safety timeout clears the
+  spinner if no result arrives.
+
+## Known Limitations
+
+- The new session starts fresh: the prompt is context, not a resumed transcript.
+  Quality depends on the summarizer model — Haiku is fast/cheap; set a stronger
+  model via `compactSession.model` for richer handoffs.
+- `CLAUDE_CONFIG_DIR` is passed only for Claude tabs that carry an account
+  profile; the summary CLI call otherwise uses the default Claude config/account.
+- Available on Claude and Codex tabs; not on Multi-Participant tabs.

--- a/Kingdom_of_Claudes_Beloved_MDs/UI_BUTTONS_AND_COMMANDS.md
+++ b/Kingdom_of_Claudes_Beloved_MDs/UI_BUTTONS_AND_COMMANDS.md
@@ -163,6 +163,12 @@ All commands are registered under the `claudeMirror.*` namespace in `package.jso
 - **HE:** מעביר את השיחה הנוכחית לספק אחר (למשל Claude ↔ Codex), ואורז את ההקשר כך שהספק החדש ממשיך מהמקום שבו הפסקת.
 - > Detail: `Kingdom_of_Claudes_Beloved_MDs/PROVIDER_HANDOFF.md`
 
+### `claudeMirror.compactSession` — "ClaUi: Compact Session to New Tab"
+- **Tooltip:** Compact session: summarize into a prompt, copy it, and open a fresh tab with it pre-filled (saves tokens)
+- **EN:** Summarizes the current session into one self-contained continuation prompt, copies it to the clipboard, and opens a fresh tab with the prompt pre-filled in the input (not sent). Lets you continue the same task in a new, low-token session. Distinct from `claudeMirror.compact` (in-place CLI compaction).
+- **HE:** מסכם את הסשן הנוכחי לפרומפט המשך אחד ועצמאי, מעתיק אותו ללוח, ופותח לשונית חדשה עם הפרומפט ממולא בתיבת הקלט (בלי לשלוח). מאפשר להמשיך את אותה משימה בסשן חדש וחסכוני בטוקנים. שונה מ-`claudeMirror.compact` (דחיסת הקשר במקום).
+- > Detail: `Kingdom_of_Claudes_Beloved_MDs/COMPACT_SESSION.md`
+
 ### `claudeMirror.switchClaudeAccountWithContext` — "ClaUi: Switch Claude Account (Carry Context)"
 - **Tooltip:** Switch Claude account, carrying context over
 - **EN:** Moves the current conversation to a different Claude account profile while preserving context (useful for separate billing/orgs).
@@ -355,6 +361,7 @@ All commands are registered under the `claudeMirror.*` namespace in `package.jso
 | Button | Tooltip | EN | HE |
 |---|---|---|---|
 | 🔍 Search chat | Search chat (Ctrl+Shift+F) | Toggle the in-chat search bar. | הפעל/כבה את שורת החיפוש בצ'אט. |
+| Compact Session | Compact session: summarize into a prompt, copy it, and open a fresh tab with it pre-filled (saves tokens) | Summarize the session into a continuation prompt, copy it, and open a fresh tab with it pre-filled. | סכם את הסשן לפרומפט המשך, העתק אותו, ופתח לשונית חדשה עם הפרומפט ממולא. |
 | Clear | Clear session and start fresh | Reset the conversation and restart the session. | אפס את השיחה והפעל מחדש את הסשן. |
 | Ultrathink lock 🔒 | Lock ultrathink on every prompt | Keep "ultrathink" prepended to every prompt. | שמור על "ultrathink" בתחילת כל פקודה. |
 | Ultrathink ⚡ | Ultrathink – boost reasoning power | Cycle ultrathink off → single → locked. | החלף ultrathink כבוי → חד-פעמי → נעול. |

--- a/TECHNICAL.md
+++ b/TECHNICAL.md
@@ -83,6 +83,7 @@ claude-code-mirror/
 |   |   |   +-- FileLogger.ts             #   Per-session file logging with rotation and rename
 |   |   |   +-- SessionStore.ts           #   Persists session metadata in globalState (incl. end-of-session summary)
 |   |   |   +-- SessionSummarizer.ts      #   End-of-session summary via Haiku (Codex low-reasoning fallback)
+|   |   |   +-- CompactSessionService.ts  #   "Compact Session": summarize a session into a continuation prompt (AI + heuristic fallback)
 |   |   |   +-- TabGroupStore.ts          #   Memento-backed CRUD for tab folders/sub-folders (workspaceState)
 |   |   |   +-- OpenTabsSnapshot.ts       #   Persists list of open tabs per-workspace for restore-on-startup (groupId/orderInGroup/lastFocusedAt/tabOrder)
 |   |   |   +-- ProjectAnalyticsStore.ts  #   Persists SessionSummary in workspaceState (per-project)
@@ -1247,6 +1248,23 @@ Added settings:
 ### Detail Doc
 
 - `Kingdom_of_Claudes_Beloved_MDs/PROVIDER_HANDOFF.md`
+
+---
+
+## Compact Session (token-saving handoff to a new tab)
+
+**Compact Session** — an InputArea button that summarizes the current session into
+one self-contained continuation prompt (AI via the analysis model, deterministic
+heuristic fallback), copies it to the clipboard, and opens a fresh tab with the
+prompt pre-filled. Lets you continue the same task in a new, low-token session.
+Distinct from `claudeMirror.compact` (the CLI's in-place context compaction).
+
+- `src/extension/session/CompactSessionService.ts` — transcript + grounding capsule -> Claude CLI summary, heuristic fallback.
+- `TabManager.compactSession()` — snapshot -> build -> clipboard -> new tab (`setForkInit`) -> `compactSessionResult`.
+- Command `claudeMirror.compactSession`; webview message `compactSession` / result `compactSessionResult`.
+- Setting `claudeMirror.compactSession.model` (empty = reuse `analysisModel`).
+
+> Detail: `Kingdom_of_Claudes_Beloved_MDs/COMPACT_SESSION.md`
 
 ---
 

--- a/html/compact-session-spec.html
+++ b/html/compact-session-spec.html
@@ -1,0 +1,177 @@
+<!DOCTYPE html>
+<html lang="he" dir="rtl">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Compact Session - כפתור דחיסת סשן</title>
+<style>
+  body {
+    font-family: "Segoe UI", Arial, sans-serif;
+    background: #f4f6f9;
+    color: #1f2933;
+    line-height: 1.7;
+    margin: 0;
+    padding: 0;
+  }
+  .wrap { max-width: 900px; margin: 0 auto; padding: 32px 24px 64px; }
+  header {
+    background: linear-gradient(135deg, #2b5876, #4e4376);
+    color: #fff;
+    padding: 36px 24px;
+    border-radius: 0 0 16px 16px;
+    text-align: center;
+  }
+  header h1 { margin: 0 0 8px; font-size: 30px; }
+  header p { margin: 0; opacity: 0.9; font-size: 17px; }
+  h2 {
+    color: #2b5876;
+    border-bottom: 2px solid #dfe6ee;
+    padding-bottom: 8px;
+    margin-top: 40px;
+  }
+  .card {
+    background: #fff;
+    border: 1px solid #e2e8f0;
+    border-radius: 12px;
+    padding: 20px 24px;
+    margin: 18px 0;
+    box-shadow: 0 1px 3px rgba(0,0,0,0.06);
+  }
+  .steps { list-style: none; padding: 0; margin: 0; }
+  .steps li {
+    display: flex;
+    align-items: flex-start;
+    gap: 12px;
+    padding: 12px 0;
+    border-bottom: 1px dashed #e2e8f0;
+  }
+  .steps li:last-child { border-bottom: none; }
+  .steps input[type="checkbox"] { margin-top: 6px; width: 18px; height: 18px; accent-color: #2b5876; }
+  .steps .txt strong { display: block; }
+  .flow {
+    background: #eef2f7;
+    border-radius: 10px;
+    padding: 16px 20px;
+    font-size: 16px;
+  }
+  .flow ol { margin: 0; padding-inline-start: 22px; }
+  .flow li { margin: 6px 0; }
+  .note {
+    background: #fff8e6;
+    border-right: 4px solid #f0b429;
+    padding: 12px 16px;
+    border-radius: 8px;
+    margin: 16px 0;
+  }
+  .pill {
+    display: inline-block;
+    background: #2b5876;
+    color: #fff;
+    border-radius: 999px;
+    padding: 2px 12px;
+    font-size: 13px;
+    margin-inline-start: 6px;
+  }
+  table { width: 100%; border-collapse: collapse; margin: 12px 0; }
+  th, td { text-align: right; padding: 10px 12px; border-bottom: 1px solid #e2e8f0; }
+  th { background: #f0f4f8; }
+</style>
+</head>
+<body>
+<header>
+  <h1>Compact Session - דחיסת סשן ומעבר חלק</h1>
+  <p>כפתור חדש שחוסך טוקנים בכך שהוא מסכם שיחה ארוכה ופותח סשן חדש וחסכוני</p>
+</header>
+
+<div class="wrap">
+
+  <h2>מה זה עושה, בשפה פשוטה</h2>
+  <div class="card">
+    <p>
+      ככל ששיחה מתארכת, היא צוברת יותר ויותר "זיכרון" (טוקנים), וזה מייקר ומאט
+      את העבודה. הכפתור החדש <strong>Compact Session</strong> פותר את זה בלחיצה אחת:
+    </p>
+    <ul>
+      <li>הוא <strong>קורא את כל השיחה הנוכחית</strong>.</li>
+      <li>מבקש מהמערכת <strong>לסכם אותה לפרומפט המשך אחד</strong> - קצר, אך שמכיל את כל מה שצריך כדי להמשיך: המטרה, מה כבר נעשה, החלטות, קבצים, בעיות פתוחות, והצעדים הבאים.</li>
+      <li><strong>מעתיק את הסיכום</strong> אוטומטית ללוח (clipboard).</li>
+      <li><strong>פותח לשונית חדשה</strong> ומדביק בה את הסיכום בתיבת ההקלדה - מוכן, בלי לשלוח - כדי שתבדוק ותשלח בעצמך.</li>
+    </ul>
+    <p>
+      התוצאה: ממשיכים בדיוק מאותה נקודה, אבל בסשן חדש ו"נקי" שצורך הרבה פחות טוקנים.
+    </p>
+  </div>
+
+  <h2>איך זה עובד, שלב אחר שלב</h2>
+  <div class="card flow">
+    <ol>
+      <li>לוחצים על הכפתור <strong>Compact</strong> שליד כפתורי החיפוש וה-Clear שמעל תיבת ההקלדה.</li>
+      <li>המערכת קוראת את השיחה ושולחת אותה לסיכום חכם (עם גיבוי אוטומטי לסיכום מהיר אם הסיכום החכם אינו זמין).</li>
+      <li>הסיכום מועתק ללוח ונפתחת לשונית חדשה עם הפרומפט מוכן בתיבה.</li>
+      <li>מופיעה הודעת אישור קצרה, והכפתור חוזר למצב רגיל.</li>
+    </ol>
+  </div>
+
+  <div class="note">
+    <strong>הבחנה חשובה:</strong> קיים כבר כפתור "Compact Context" שדוחס את ההקשר
+    <em>בתוך אותו סשן</em>. הכפתור החדש שונה - הוא יוצר פרומפט נייד ופותח
+    <em>סשן חדש לגמרי</em>.
+  </div>
+
+  <h2>שלבי הביצוע (הושלמו)</h2>
+  <div class="card">
+    <ul class="steps">
+      <li>
+        <input type="checkbox" checked>
+        <span class="txt"><strong>הגדרת ערוץ התקשורת</strong> בין הממשק למנוע - הודעת בקשה והודעת תוצאה.</span>
+      </li>
+      <li>
+        <input type="checkbox" checked>
+        <span class="txt"><strong>מנוע הסיכום</strong> - קורא את השיחה, מייצר פרומפט המשך מקיף, עם נפילה-לאחור לסיכום מהיר.</span>
+      </li>
+      <li>
+        <input type="checkbox" checked>
+        <span class="txt"><strong>תזמור הפעולה</strong> - העתקה ללוח, פתיחת לשונית חדשה, ומילוי הפרומפט בתיבה.</span>
+      </li>
+      <li>
+        <input type="checkbox" checked>
+        <span class="txt"><strong>הכפתור בממשק</strong> - עם אנימציית טעינה, הודעת אישור, וטולטיפ הסבר.</span>
+      </li>
+      <li>
+        <input type="checkbox" checked>
+        <span class="txt"><strong>זמין גם דרך לוח הפקודות</strong> (Command Palette) ולא רק ככפתור.</span>
+      </li>
+      <li>
+        <input type="checkbox" checked>
+        <span class="txt"><strong>עזרה דו-לשונית ותיעוד</strong> - הכפתור נוסף לפאנל ה-Help (עברית ואנגלית) ולמסמכי התיעוד.</span>
+      </li>
+      <li>
+        <input type="checkbox" checked>
+        <span class="txt"><strong>בנייה ובדיקת קומפילציה</strong> עברו בהצלחה ללא שגיאות.</span>
+      </li>
+    </ul>
+  </div>
+
+  <h2>הגדרה שכדאי להכיר</h2>
+  <div class="card">
+    <table>
+      <tr><th>הגדרה</th><th>ברירת מחדל</th><th>למה זה טוב</th></tr>
+      <tr>
+        <td>מודל הסיכום <span class="pill">compactSession.model</span></td>
+        <td>ריק</td>
+        <td>ריק = שימוש במודל הניתוח הקיים (מהיר וזול). אפשר להגדיר מודל חזק יותר לסיכום איכותי יותר.</td>
+      </tr>
+    </table>
+  </div>
+
+  <h2>מגבלות ידועות</h2>
+  <div class="card">
+    <ul>
+      <li>הסשן החדש מתחיל "רענן" - הפרומפט הוא ההקשר, לא שחזור מלא של ההיסטוריה. איכות הסיכום תלויה במודל שנבחר.</li>
+      <li>זמין בלשוניות Claude ו-Codex; לא בלשוניות ריבוי-משתתפים.</li>
+    </ul>
+  </div>
+
+</div>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -179,6 +179,10 @@
         "title": "ClaUi: Switch Provider (Carry Context)"
       },
       {
+        "command": "claudeMirror.compactSession",
+        "title": "ClaUi: Compact Session to New Tab"
+      },
+      {
         "command": "claudeMirror.switchClaudeAccountWithContext",
         "title": "ClaUi: Switch Claude Account (Carry Context)"
       },
@@ -301,6 +305,11 @@
           "type": "boolean",
           "default": true,
           "description": "Enable cross-provider session handoff (Claude Code <-> Codex) with context capsule transfer."
+        },
+        "claudeMirror.compactSession.model": {
+          "type": "string",
+          "default": "",
+          "description": "Model used by the 'Compact Session' button to summarize a session into a continuation prompt. Leave empty to reuse claudeMirror.analysisModel (Haiku by default). Set a stronger model (e.g. a Sonnet id) for higher-quality handoff prompts."
         },
         "claudeMirror.reviewLoop.autoStart": {
           "type": "boolean",

--- a/src/extension/commands.ts
+++ b/src/extension/commands.ts
@@ -375,6 +375,26 @@ export function registerCommands(
       vscode.window.showErrorMessage(`Provider handoff failed: ${message}`);
     }
   };
+  const runCompactSession = async (args?: { sourceTabId?: string }): Promise<void> => {
+    const sourceTab = args?.sourceTabId ? tabManager.getTabById(args.sourceTabId) : tabManager.getActiveTab();
+    if (!sourceTab) {
+      vscode.window.showWarningMessage('No active ClaUi tab to compact. Start or open a session first.');
+      return;
+    }
+    try {
+      const result = await tabManager.compactSession({ sourceTabId: sourceTab.id });
+      const via = result.source === 'ai' ? 'AI summary' : 'quick summary';
+      vscode.window.showInformationMessage(
+        `Compact Session ready (${via}). Opened a new tab with the prompt pre-filled and copied it to the clipboard.`,
+      );
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      vscode.window.showErrorMessage(`Compact Session failed: ${message}`);
+      // Re-throw so webview-initiated runs receive a failure result via the
+      // MessageHandler catch (which clears the button's loading state).
+      throw err;
+    }
+  };
   let showHistoryInFlight = false;
   let showHistorySeq = 0;
   let openPlanDocsInFlight = false;
@@ -536,6 +556,14 @@ export function registerCommands(
       'claudeMirror.switchProviderWithContext',
       async (args?: { sourceTabId?: string; targetProvider?: 'claude' | 'codex'; keepSourceOpen?: boolean }) => {
         await runProviderHandoff(args);
+      }
+    ),
+
+    // Compact the active session into a continuation prompt and open a fresh tab
+    vscode.commands.registerCommand(
+      'claudeMirror.compactSession',
+      async (args?: { sourceTabId?: string }) => {
+        await runCompactSession(args);
       }
     ),
 

--- a/src/extension/session/CompactSessionService.ts
+++ b/src/extension/session/CompactSessionService.ts
@@ -1,0 +1,281 @@
+import * as vscode from 'vscode';
+import { spawn } from 'child_process';
+import { buildClaudeCliEnv } from '../process/envUtils';
+import { killProcessTree } from '../process/killTree';
+import type { HandoffContextBuilder } from './handoff/HandoffContextBuilder';
+import type { HandoffPromptComposer } from './handoff/HandoffPromptComposer';
+import type { HandoffCapsule, HandoffSourceSnapshot } from './handoff/HandoffTypes';
+import type { SerializedChatMessage } from '../types/webview-messages';
+
+/**
+ * Builds the token-saving "Compact Session" handoff prompt.
+ *
+ * Pipeline: read the source session transcript -> ground it with a structured
+ * capsule (objective/files/blockers extracted heuristically) -> ask the Claude
+ * CLI to write ONE self-contained continuation prompt that a fresh session can
+ * use to seamlessly resume the work with far fewer tokens than the raw history.
+ *
+ * Falls back to the deterministic HandoffPromptComposer output when the CLI
+ * summary is unavailable (empty transcript, spawn failure, timeout, non-zero
+ * exit), so the feature always produces a usable prompt.
+ */
+
+// Bigger than the tooltip summarizer: we want the whole session captured.
+const MAX_TRANSCRIPT_CHARS = 24_000;
+const CLI_TIMEOUT_MS = 90_000;
+// Capture far more of the conversation than the default handoff capsule (8 turns).
+const CAPSULE_TURN_BUDGET = 60;
+const CAPSULE_PER_TURN_TEXT_BUDGET = 1600;
+
+export interface CompactSessionResult {
+  /** The generated handoff prompt, ready to paste into a fresh session. */
+  prompt: string;
+  /** Which engine produced it: 'ai' (CLI summary) or 'heuristic' (fallback). */
+  source: 'ai' | 'heuristic';
+}
+
+export class CompactSessionService {
+  private log: (msg: string) => void = () => {};
+
+  constructor(
+    private readonly contextBuilder: HandoffContextBuilder,
+    private readonly promptComposer: HandoffPromptComposer,
+    logger?: (msg: string) => void,
+  ) {
+    if (logger) {
+      this.log = logger;
+    }
+  }
+
+  setLogger(logger: (msg: string) => void): void {
+    this.log = logger;
+  }
+
+  /**
+   * Produce the compact handoff prompt for a source session snapshot.
+   * Never rejects: always resolves with a usable prompt (AI or heuristic).
+   */
+  async build(snapshot: HandoffSourceSnapshot, opts?: { claudeConfigDir?: string }): Promise<CompactSessionResult> {
+    // Structured capsule doubles as grounding for the AI prompt and as the
+    // deterministic fallback if the CLI summary fails.
+    const capsule = this.contextBuilder.buildCapsule({
+      source: snapshot,
+      targetProvider: snapshot.provider,
+      turnBudget: CAPSULE_TURN_BUDGET,
+      perTurnTextBudget: CAPSULE_PER_TURN_TEXT_BUDGET,
+    });
+    const heuristicPrompt = this.promptComposer.compose(capsule);
+
+    const transcript = this.buildTranscript(snapshot.messages);
+    if (!transcript) {
+      this.log('[CompactSession] Transcript empty - using heuristic capsule prompt');
+      return { prompt: heuristicPrompt, source: 'heuristic' };
+    }
+
+    const instruction = this.buildInstruction(snapshot, capsule, transcript);
+    const aiPrompt = await this.runCli(instruction, opts?.claudeConfigDir);
+    if (aiPrompt) {
+      this.log(`[CompactSession] AI summary produced (${aiPrompt.length} chars)`);
+      return { prompt: aiPrompt, source: 'ai' };
+    }
+
+    this.log('[CompactSession] AI summary unavailable - falling back to heuristic capsule prompt');
+    return { prompt: heuristicPrompt, source: 'heuristic' };
+  }
+
+  // ---------- Transcript ----------
+
+  private buildTranscript(messages: SerializedChatMessage[]): string {
+    const source = Array.isArray(messages) ? messages : [];
+    const lines: string[] = [];
+    for (const msg of source) {
+      const text = this.extractPlainText(msg);
+      if (!text) {
+        continue;
+      }
+      const speaker = msg.role === 'user' ? 'USER' : 'ASSISTANT';
+      lines.push(`${speaker}: ${text}`);
+    }
+    if (lines.length === 0) {
+      return '';
+    }
+    return this.truncatePreservingHeadAndTail(lines.join('\n\n'));
+  }
+
+  private extractPlainText(msg: SerializedChatMessage): string {
+    const content = (msg as unknown as { content?: unknown }).content;
+    if (typeof content === 'string') {
+      return content.trim();
+    }
+    if (!Array.isArray(content)) {
+      return '';
+    }
+    const parts: string[] = [];
+    for (const block of content as Array<{ type?: string; text?: string; name?: string }>) {
+      if (block?.type === 'text' && typeof block.text === 'string') {
+        parts.push(block.text);
+      } else if (block?.type === 'tool_use') {
+        // Tool names carry meaningful signal (which files/commands were touched)
+        // without dragging in the full tool payload.
+        parts.push(`[used tool: ${typeof block.name === 'string' ? block.name : 'tool'}]`);
+      }
+    }
+    return parts.join('\n').trim();
+  }
+
+  /** Keep the opening of the session (goal) and the tail (current state). */
+  private truncatePreservingHeadAndTail(transcript: string): string {
+    if (transcript.length <= MAX_TRANSCRIPT_CHARS) {
+      return transcript;
+    }
+    // The tail (recent work / current state) matters most, so weight it heavier.
+    const headSize = Math.floor(MAX_TRANSCRIPT_CHARS * 0.35);
+    const tailSize = MAX_TRANSCRIPT_CHARS - headSize - 24;
+    const head = transcript.slice(0, headSize);
+    const tail = transcript.slice(transcript.length - tailSize);
+    return `${head}\n\n...[middle of the conversation truncated to save space]...\n\n${tail}`;
+  }
+
+  // ---------- Instruction prompt ----------
+
+  private buildInstruction(
+    snapshot: HandoffSourceSnapshot,
+    capsule: HandoffCapsule,
+    transcript: string,
+  ): string {
+    const groundingLines: string[] = [];
+    if (capsule.workspace.cwd) {
+      groundingLines.push(`Working directory: ${capsule.workspace.cwd}`);
+    }
+    if (capsule.workspace.branch) {
+      groundingLines.push(`Git branch: ${capsule.workspace.branch}`);
+    }
+    if (snapshot.model) {
+      groundingLines.push(`Model used: ${snapshot.model}`);
+    }
+    if (capsule.touchedFiles.length > 0) {
+      groundingLines.push(`Files referenced: ${capsule.touchedFiles.join(', ')}`);
+    }
+    if (capsule.task.blockers.length > 0) {
+      groundingLines.push(`Possible blockers detected: ${capsule.task.blockers.join(' | ')}`);
+    }
+    const grounding = groundingLines.length > 0 ? groundingLines.join('\n') : '(none extracted)';
+
+    return [
+      'You are preparing a HANDOFF PROMPT that will be pasted as the FIRST message into a brand-new coding-assistant session.',
+      'The new session will NOT have access to this conversation. Your job is to preserve ALL information needed to continue the work seamlessly, while being far more compact than the raw transcript (the whole point is to save tokens).',
+      '',
+      'Write the handoff prompt as if the user is briefing a fresh assistant. Be specific, concrete, and complete. Organize it into these clearly-labelled sections:',
+      '1. Objective - what we are ultimately trying to achieve.',
+      '2. Progress so far - what has already been done, tried, and what worked or failed.',
+      '3. Current state - exactly where things stand right now.',
+      '4. Key decisions and rationale - important choices made and why.',
+      '5. Environment and files - working directory, repo/branch, and the specific files created or modified (exact paths).',
+      '6. Open problems / blockers - anything unresolved.',
+      '7. Next steps - the concrete actions the new session should take next.',
+      '',
+      'Rules:',
+      '- Preserve concrete details: exact file paths, function/command/identifier names, error messages, and decisions. Do NOT invent anything that is not supported by the material below.',
+      '- Be concise but COMPLETE: drop chit-chat and repetitive tool noise, keep everything that matters for continuation.',
+      '- Write in the SAME LANGUAGE the user used in the conversation.',
+      '- Output ONLY the handoff prompt text itself. No preamble, no meta commentary, and do NOT wrap the whole answer in a markdown code fence.',
+      '',
+      '--- Structured context (auto-extracted signals) ---',
+      grounding,
+      '',
+      '--- Conversation transcript (may be truncated in the middle) ---',
+      transcript,
+    ].join('\n');
+  }
+
+  // ---------- CLI call ----------
+
+  private resolveModel(): string {
+    const config = vscode.workspace.getConfiguration('claudeMirror');
+    const dedicated = config.get<string>('compactSession.model', '').trim();
+    if (dedicated) {
+      return dedicated;
+    }
+    return config.get<string>('analysisModel', 'claude-haiku-4-5-20251001');
+  }
+
+  private runCli(prompt: string, claudeConfigDir?: string): Promise<string | null> {
+    return new Promise<string | null>((resolve) => {
+      const config = vscode.workspace.getConfiguration('claudeMirror');
+      const cliPath = config.get<string>('cliPath', 'claude');
+      const model = this.resolveModel();
+      const args = ['-p', '--model', model];
+      const env = buildClaudeCliEnv();
+      if (claudeConfigDir?.trim()) {
+        env.CLAUDE_CONFIG_DIR = claudeConfigDir;
+      }
+
+      let stdout = '';
+      let settled = false;
+
+      const finish = (result: string | null) => {
+        if (settled) return;
+        settled = true;
+        clearTimeout(timer);
+        resolve(result);
+      };
+
+      let child;
+      try {
+        child = spawn(cliPath, args, {
+          env,
+          stdio: ['pipe', 'pipe', 'pipe'],
+          shell: true,
+        });
+        this.log(`[CompactSession] spawn pid=${child.pid ?? '?'} model=${model} promptLen=${prompt.length}`);
+      } catch (err) {
+        this.log(`[CompactSession] spawn threw: ${err}`);
+        finish(null);
+        return;
+      }
+
+      const timer = setTimeout(() => {
+        const partial = stdout ? this.sanitize(stdout) : null;
+        this.log(`[CompactSession] timeout (${CLI_TIMEOUT_MS}ms), partialLen=${partial?.length ?? 0}`);
+        killProcessTree(child);
+        finish(partial);
+      }, CLI_TIMEOUT_MS);
+
+      child.stdout?.on('data', (chunk: Buffer) => {
+        stdout += chunk.toString('utf-8');
+      });
+      child.stderr?.on('data', (chunk: Buffer) => {
+        this.log(`[CompactSession] stderr: ${chunk.toString('utf-8').trim()}`);
+      });
+      child.on('error', (err) => {
+        this.log(`[CompactSession] error: ${err.message}`);
+        finish(null);
+      });
+      child.on('exit', (code) => {
+        this.log(`[CompactSession] exit code=${code}`);
+        if (code !== 0) {
+          finish(null);
+          return;
+        }
+        finish(this.sanitize(stdout));
+      });
+      child.stdin?.write(prompt);
+      child.stdin?.end();
+    });
+  }
+
+  // ---------- Sanitize ----------
+
+  private sanitize(raw: string): string | null {
+    let cleaned = raw.trim();
+    if (!cleaned) {
+      return null;
+    }
+    // Strip a single wrapping markdown code fence if the model added one anyway.
+    const fenceMatch = cleaned.match(/^```[a-zA-Z]*\n([\s\S]*?)\n```$/);
+    if (fenceMatch) {
+      cleaned = fenceMatch[1].trim();
+    }
+    return cleaned || null;
+  }
+}

--- a/src/extension/session/TabManager.ts
+++ b/src/extension/session/TabManager.ts
@@ -23,6 +23,7 @@ import { HandoffContextBuilder } from './handoff/HandoffContextBuilder';
 import { HandoffPromptComposer } from './handoff/HandoffPromptComposer';
 import { HandoffArtifactStore } from './handoff/HandoffArtifactStore';
 import { HandoffOrchestrator, type HandoffTargetRuntime } from './handoff/HandoffOrchestrator';
+import { CompactSessionService } from './CompactSessionService';
 import type { HandoffProvider, HandoffSessionRequest } from './handoff/HandoffTypes';
 import { isHandoffProvider } from './handoff/HandoffTypes';
 import {
@@ -95,6 +96,7 @@ export class TabManager {
   private readonly handoffOrchestrator: HandoffOrchestrator;
   private readonly handoffLocks = new Set<string>();
   private readonly handoffLastByTab = new Map<string, number>();
+  private readonly compactSessionService: CompactSessionService;
 
   /** Shared workstream manager, injected after construction to avoid circular dependency */
   workstreamManager: import('../workstream/WorkstreamManager').WorkstreamManager | null = null;
@@ -163,6 +165,11 @@ export class TabManager {
       new HandoffContextBuilder(this.log),
       new HandoffPromptComposer(),
       new HandoffArtifactStore(artifactsRoot, this.log, { persistToDisk: storeArtifacts }),
+      this.log,
+    );
+    this.compactSessionService = new CompactSessionService(
+      new HandoffContextBuilder(this.log),
+      new HandoffPromptComposer(),
       this.log,
     );
 
@@ -961,6 +968,84 @@ export class TabManager {
       }
 
       return { targetTabId: result.targetTabId, artifactPath };
+    } finally {
+      this.handoffLocks.delete(sourceTab.id);
+    }
+  }
+
+  /**
+   * "Compact Session": summarize the source session into a self-contained
+   * continuation prompt, copy it to the clipboard, and open a fresh tab (same
+   * provider) with that prompt pre-filled in the input box (NOT auto-sent).
+   * Lets the user carry the full task context into a new, low-token session.
+   *
+   * Posts a `compactSessionResult` back to the source tab's webview on success;
+   * throws on failure so the caller can surface the error (and, for webview-
+   * initiated runs, post the failure result).
+   */
+  async compactSession(request: { sourceTabId?: string }): Promise<{
+    targetTabId: string;
+    promptChars: number;
+    source: 'ai' | 'heuristic';
+  }> {
+    const sourceTab = request.sourceTabId ? this.getTabById(request.sourceTabId) : this.getActiveTab();
+    if (!sourceTab) {
+      throw new Error('No source tab found to compact.');
+    }
+    if (sourceTab instanceof MultiParticipantSessionTab) {
+      throw new Error('Multi-participant tabs do not support Compact Session.');
+    }
+
+    const sourceProvider = sourceTab.getProvider();
+    if (!isHandoffProvider(sourceProvider)) {
+      throw new Error(`Provider "${sourceProvider}" does not support Compact Session.`);
+    }
+
+    if (this.handoffLocks.has(sourceTab.id)) {
+      throw new Error('A handoff or compact is already in progress for this tab.');
+    }
+
+    this.handoffLocks.add(sourceTab.id);
+    try {
+      this.log(`[Compact] start tab=${sourceTab.id} provider=${sourceProvider}`);
+      const snapshot = await sourceTab.collectHandoffSnapshot();
+      if (!snapshot.messages || snapshot.messages.length === 0) {
+        throw new Error('This session has no conversation yet to compact.');
+      }
+
+      const claudeConfigDir =
+        sourceTab instanceof SessionTab ? sourceTab.getClaudeConfigDir() ?? undefined : undefined;
+      const startedAt = Date.now();
+      const compact = await this.compactSessionService.build(snapshot, { claudeConfigDir });
+      this.log(
+        `[Compact] prompt built tab=${sourceTab.id} source=${compact.source} chars=${compact.prompt.length} durationMs=${Date.now() - startedAt}`,
+      );
+
+      // Clipboard copy (best-effort backup so the user can paste anywhere).
+      let copiedToClipboard = false;
+      try {
+        await vscode.env.clipboard.writeText(compact.prompt);
+        copiedToClipboard = true;
+      } catch (err) {
+        this.log(`[Compact] clipboard write failed: ${err instanceof Error ? err.message : String(err)}`);
+      }
+
+      // Open a fresh tab (same provider) and pre-fill its input with the prompt.
+      const targetTab = this.createTabForProvider(sourceProvider);
+      targetTab.setForkInit({ promptText: compact.prompt, messages: [] });
+      await targetTab.startSession({ cwd: snapshot.cwd });
+      this.log(`[Compact] opened target tab=${targetTab.id} (input pre-filled, not sent)`);
+
+      sourceTab.postMessage({
+        type: 'compactSessionResult',
+        success: true,
+        promptChars: compact.prompt.length,
+        openedNewTab: true,
+        copiedToClipboard,
+        source: compact.source,
+      });
+
+      return { targetTabId: targetTab.id, promptChars: compact.prompt.length, source: compact.source };
     } finally {
       this.handoffLocks.delete(sourceTab.id);
     }

--- a/src/extension/types/webview-messages.ts
+++ b/src/extension/types/webview-messages.ts
@@ -223,6 +223,16 @@ export interface CompactRequest {
   instructions?: string;
 }
 
+/**
+ * "Compact Session" (token-saving handoff): read the current session, summarize
+ * it into a comprehensive self-contained continuation prompt, copy it to the
+ * clipboard, and open a fresh tab with that prompt pre-filled in the input.
+ * Distinct from `compact` (the CLI's in-place context compaction).
+ */
+export interface CompactSessionRequest {
+  type: 'compactSession';
+}
+
 export interface StartSessionRequest {
   type: 'startSession';
   workspacePath?: string;
@@ -1095,6 +1105,7 @@ export type WebviewToExtensionMessage =
   | CancelScheduledMessageRequest
   | CancelRequest
   | CompactRequest
+  | CompactSessionRequest
   | StartSessionRequest
   | StopSessionRequest
   | ResumeSessionRequest
@@ -1674,6 +1685,26 @@ export interface ToolActivityMessage {
 export interface PermissionModeSettingMessage {
   type: 'permissionModeSetting';
   mode: 'full-access' | 'supervised';
+}
+
+/**
+ * Result of a "Compact Session" run (see CompactSessionRequest). Posted back to
+ * the SOURCE tab's webview so it can clear the button's loading state and show a
+ * transient notice.
+ */
+export interface CompactSessionResultMessage {
+  type: 'compactSessionResult';
+  success: boolean;
+  /** Failure reason when success is false. */
+  error?: string;
+  /** Character length of the generated prompt (shown in the success notice). */
+  promptChars?: number;
+  /** True when a new tab was opened and its input pre-filled with the prompt. */
+  openedNewTab?: boolean;
+  /** True when the prompt was also copied to the OS clipboard. */
+  copiedToClipboard?: boolean;
+  /** Which engine produced the prompt: 'ai' (CLI summary) or 'heuristic' (fallback). */
+  source?: 'ai' | 'heuristic';
 }
 
 export interface GitPushResultMessage {
@@ -2925,6 +2956,7 @@ export type ExtensionToWebviewMessage =
   | ActivitySummaryMessage
   | ToolActivityMessage
   | PermissionModeSettingMessage
+  | CompactSessionResultMessage
   | GitPushResultMessage
   | GitPushSettingsMessage
   | WorktreeListMessage

--- a/src/extension/webview/CodexMessageHandler.ts
+++ b/src/extension/webview/CodexMessageHandler.ts
@@ -962,6 +962,20 @@ export class CodexMessageHandler {
             });
           break;
 
+        case 'compactSession':
+          this.log('Compact session requested (Codex handler)');
+          void vscode.commands.executeCommand('claudeMirror.compactSession', {
+            sourceTabId: this.tabId,
+          }).then(
+            () => undefined,
+            (err: unknown) => {
+              const message = this.errMsg(err);
+              this.log(`Failed compactSession (Codex handler): ${message}`);
+              this.webview.postMessage({ type: 'compactSessionResult', success: false, error: message });
+            },
+          );
+          break;
+
         case 'switchProviderWithContext':
           this.log(`Switch provider with context requested: "${msg.targetProvider}" (Codex handler)`);
           void vscode.commands.executeCommand('claudeMirror.switchProviderWithContext', {

--- a/src/extension/webview/MessageHandler.ts
+++ b/src/extension/webview/MessageHandler.ts
@@ -2199,6 +2199,20 @@ export class MessageHandler {
             });
           break;
 
+        case 'compactSession':
+          this.log('Compact session requested');
+          void vscode.commands.executeCommand('claudeMirror.compactSession', {
+            sourceTabId: this.tabId,
+          }).then(
+            () => undefined,
+            (err: unknown) => {
+              const message = err instanceof Error ? err.message : String(err);
+              this.log(`Failed compactSession: ${message}`);
+              this.webview.postMessage({ type: 'compactSessionResult', success: false, error: message });
+            },
+          );
+          break;
+
         case 'switchProviderWithContext':
           this.log(`Switch provider with context requested: "${msg.targetProvider}"`);
           void vscode.commands.executeCommand('claudeMirror.switchProviderWithContext', {

--- a/src/webview/components/Help/helpContent.ts
+++ b/src/webview/components/Help/helpContent.ts
@@ -706,6 +706,14 @@ export const HELP_ENTRIES: HelpEntry[] = [
     detailHe: "הפעל/כבה את שורת החיפוש בצ'אט.",
   },
   {
+    id: 'inputarea-compact-session',
+    section: 'inputarea',
+    name: 'Compact Session',
+    tooltip: 'Compact session: summarize into a prompt, copy it, and open a fresh tab with it pre-filled (saves tokens)',
+    detailEn: "Reads the current session, asks the analysis model to summarize it into one self-contained continuation prompt (objective, progress, decisions, files, blockers, next steps), copies that prompt to the clipboard, and opens a fresh tab with the prompt pre-filled in the input (not sent). Lets you continue the same task in a brand-new, low-token session. Falls back to a quick structured summary if the AI call is unavailable.",
+    detailHe: 'קורא את הסשן הנוכחי, מבקש ממודל הניתוח לסכם אותו לפרומפט המשך אחד ועצמאי (מטרה, התקדמות, החלטות, קבצים, חוסמים, צעדים הבאים), מעתיק את הפרומפט ללוח (clipboard), ופותח לשונית חדשה עם הפרומפט ממולא בתיבת הקלט (בלי לשלוח). מאפשר להמשיך את אותה משימה בסשן חדש וחסכוני בטוקנים. אם קריאת ה-AI לא זמינה, נופל לאחור לסיכום מובנה מהיר.',
+  },
+  {
     id: 'inputarea-clear',
     section: 'inputarea',
     name: 'Clear',

--- a/src/webview/components/InputArea/InputArea.tsx
+++ b/src/webview/components/InputArea/InputArea.tsx
@@ -95,6 +95,10 @@ export const InputArea: React.FC = () => {
     addToPromptHistory,
     pendingApproval,
     setPendingApproval,
+    compactingSession,
+    setCompactingSession,
+    compactSessionNotice,
+    setCompactSessionNotice,
     gitPushResult,
     setGitPushResult,
     gitPushConfigPanelOpen,
@@ -1002,6 +1006,45 @@ export const InputArea: React.FC = () => {
     postToExtension({ type: 'clearSession' });
   }, []);
 
+  /**
+   * Compact Session: ask the extension to summarize this session into a
+   * continuation prompt, copy it to the clipboard, and open a fresh tab with
+   * that prompt pre-filled. Guarded against double-runs; the loading state is
+   * cleared by the `compactSessionResult` message (with a safety timeout).
+   */
+  const compactTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const handleCompactSession = useCallback(() => {
+    if (!isConnected || inputLockedByHandoff || compactingSession) return;
+    setCompactSessionNotice(null);
+    setCompactingSession(true);
+    if (compactTimeoutRef.current) clearTimeout(compactTimeoutRef.current);
+    // Safety: the CLI summary can run up to ~90s; give it headroom before giving up.
+    compactTimeoutRef.current = setTimeout(() => {
+      setCompactingSession(false);
+      setCompactSessionNotice({ success: false, text: 'Compact timed out. Please try again.' });
+      compactTimeoutRef.current = null;
+    }, 120_000);
+    postToExtension({ type: 'compactSession' } as any);
+  }, [isConnected, inputLockedByHandoff, compactingSession, setCompactingSession, setCompactSessionNotice]);
+
+  // Clear the safety timeout as soon as a result arrives (or on unmount).
+  useEffect(() => {
+    if (!compactingSession && compactTimeoutRef.current) {
+      clearTimeout(compactTimeoutRef.current);
+      compactTimeoutRef.current = null;
+    }
+  }, [compactingSession]);
+  useEffect(() => () => {
+    if (compactTimeoutRef.current) clearTimeout(compactTimeoutRef.current);
+  }, []);
+
+  // Auto-dismiss the compact notice after a few seconds.
+  useEffect(() => {
+    if (!compactSessionNotice) return;
+    const id = setTimeout(() => setCompactSessionNotice(null), 6000);
+    return () => clearTimeout(id);
+  }, [compactSessionNotice, setCompactSessionNotice]);
+
   const handleClearGoal = useCallback(() => {
     if (!isConnected) return;
     postToExtension({ type: 'sendMessage', text: '/goal clear' });
@@ -1560,6 +1603,13 @@ export const InputArea: React.FC = () => {
           ))}
         </div>
       )}
+      {/* Compact Session result toast (reuses git-push-toast styling) */}
+      {compactSessionNotice && (
+        <div className={`git-push-toast ${compactSessionNotice.success ? 'success' : 'error'}`}>
+          <span>{compactSessionNotice.text}</span>
+          <button className="git-push-toast-dismiss" onClick={() => setCompactSessionNotice(null)} data-tooltip="Dismiss">x</button>
+        </div>
+      )}
       {/* Git push result toast */}
       {gitPushResult && (
         <div className={`git-push-toast ${gitPushResult.success ? 'success' : 'error'}`}>
@@ -1720,6 +1770,30 @@ export const InputArea: React.FC = () => {
               <circle cx="11" cy="11" r="8" />
               <line x1="21" y1="21" x2="16.65" y2="16.65" />
             </svg>
+          </button>
+          <button
+            className={`compact-session-button${compactingSession ? ' compacting' : ''}`}
+            onClick={handleCompactSession}
+            disabled={!isConnected || inputLockedByHandoff || compactingSession}
+            data-tooltip={
+              compactingSession
+                ? 'Compacting session… summarizing into a new-session prompt'
+                : 'Compact session: summarize into a prompt, copy it, and open a fresh tab with it pre-filled (saves tokens)'
+            }
+            aria-busy={compactingSession}
+          >
+            {compactingSession ? (
+              <svg className="compact-spin" width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <path d="M21 12a9 9 0 1 1-6.219-8.56" />
+              </svg>
+            ) : (
+              <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                <polyline points="4 14 10 14 10 20" />
+                <polyline points="20 10 14 10 14 4" />
+                <line x1="14" y1="10" x2="21" y2="3" />
+                <line x1="3" y1="21" x2="10" y2="14" />
+              </svg>
+            )}
           </button>
           <button
             className="clear-session-button"

--- a/src/webview/hooks/useClaudeStream.ts
+++ b/src/webview/hooks/useClaudeStream.ts
@@ -54,6 +54,8 @@ export function useClaudeStream(): void {
     setActivitySummaryDismissed,
     setActivitySummaryEnabled,
     setPermissionMode,
+    setCompactingSession,
+    setCompactSessionNotice,
     setGitPushSettings,
     setGitPushResult,
     setGitPushRunning,
@@ -794,6 +796,23 @@ export function useClaudeStream(): void {
           setPendingApproval(null);
           break;
 
+        case 'compactSessionResult': {
+          setCompactingSession(false);
+          if (msg.success) {
+            const bits: string[] = ['Compact prompt ready.'];
+            if (msg.openedNewTab) bits.push('Opened a new tab with it pre-filled.');
+            if (msg.copiedToClipboard) bits.push('Copied to clipboard.');
+            if (msg.source === 'heuristic') bits.push('(quick summary — AI unavailable)');
+            setCompactSessionNotice({ success: true, text: bits.join(' ') });
+          } else {
+            setCompactSessionNotice({
+              success: false,
+              text: `Compact failed: ${msg.error || 'unknown error'}`,
+            });
+          }
+          break;
+        }
+
         case 'gitPushResult':
           setGitPushRunning(false);
           setGitPushResult({ success: msg.success, output: msg.output });
@@ -1440,6 +1459,8 @@ export function useClaudeStream(): void {
     setActivitySummaryDismissed,
     setActivitySummaryEnabled,
     setPermissionMode,
+    setCompactingSession,
+    setCompactSessionNotice,
     setGitPushSettings,
     setGitPushResult,
     setGitPushRunning,

--- a/src/webview/state/store.ts
+++ b/src/webview/state/store.ts
@@ -249,6 +249,10 @@ export interface AppState {
   // Permission mode
   permissionMode: 'full-access' | 'supervised';
 
+  // Compact Session (token-saving handoff to a new tab)
+  compactingSession: boolean;
+  compactSessionNotice: { success: boolean; text: string } | null;
+
   // Git push
   gitPushSettings: { enabled: boolean; scriptPath: string; commitMessageTemplate: string } | null;
   gitPushResult: { success: boolean; output: string } | null;
@@ -782,6 +786,8 @@ export interface AppState {
   setPermissionMode: (mode: 'full-access' | 'supervised') => void;
   setProjectPromptHistory: (history: string[]) => void;
   setGlobalPromptHistory: (history: string[]) => void;
+  setCompactingSession: (running: boolean) => void;
+  setCompactSessionNotice: (notice: { success: boolean; text: string } | null) => void;
   setGitPushSettings: (settings: { enabled: boolean; scriptPath: string; commitMessageTemplate: string }) => void;
   setGitPushResult: (result: { success: boolean; output: string } | null) => void;
   setGitPushConfigPanelOpen: (open: boolean) => void;
@@ -1203,6 +1209,8 @@ export const useAppStore = create<AppState>((set, get) => ({
   activitySummaryDismissed: false,
   activitySummaryEnabled: true,
   permissionMode: 'full-access' as const,
+  compactingSession: false,
+  compactSessionNotice: null,
   gitPushSettings: null,
   gitPushResult: null,
   gitPushConfigPanelOpen: false,
@@ -2247,6 +2255,9 @@ export const useAppStore = create<AppState>((set, get) => ({
 
   setGlobalPromptHistory: (history) => set({ globalPromptHistory: history }),
 
+  setCompactingSession: (running) => set({ compactingSession: running }),
+  setCompactSessionNotice: (notice) => set({ compactSessionNotice: notice }),
+
   setGitPushSettings: (settings) => set({ gitPushSettings: settings }),
   setGitPushResult: (result) => set({ gitPushResult: result }),
   setGitPushConfigPanelOpen: (open) => set({ gitPushConfigPanelOpen: open }),
@@ -3210,6 +3221,8 @@ export const useAppStore = create<AppState>((set, get) => ({
       activitySummaryDismissed: false,
       sessionSkills: [],
       permissionMode: 'full-access' as const,
+      compactingSession: false,
+      compactSessionNotice: null,
       gitPushSettings: null,
       gitPushResult: null,
       gitPushConfigPanelOpen: false,

--- a/src/webview/styles/global.css
+++ b/src/webview/styles/global.css
@@ -1052,6 +1052,50 @@ html, body, #root {
   cursor: not-allowed;
 }
 
+.compact-session-button {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 18px;
+  padding: 0;
+  background: none;
+  border: 1px solid var(--vscode-input-border, #3c3c3c);
+  border-radius: 4px;
+  color: var(--vscode-descriptionForeground);
+  cursor: pointer;
+}
+
+.compact-session-button svg {
+  width: 12px;
+  height: 12px;
+}
+
+.compact-session-button:hover:not(:disabled) {
+  background: var(--vscode-toolbar-hoverBackground);
+  color: var(--vscode-editor-foreground);
+  border-color: var(--vscode-focusBorder);
+}
+
+.compact-session-button:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.compact-session-button.compacting {
+  color: var(--vscode-focusBorder);
+  opacity: 1;
+}
+
+.compact-session-button .compact-spin {
+  animation: compact-spin 0.9s linear infinite;
+}
+
+@keyframes compact-spin {
+  from { transform: rotate(0deg); }
+  to { transform: rotate(360deg); }
+}
+
 .browse-stack {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## What & why

Long conversations accumulate context (tokens), which slows responses and raises cost. **Compact Session** lets you carry the full task context into a brand‑new, low‑token session in one click.

This is **distinct from the CLI's in‑place `/compact`** (`claudeMirror.compact`), which compresses the context window *within the same session*. Compact Session instead produces a portable prompt and starts a *fresh* session.

## What it does

Adds a **Compact** button to the input area (next to Search / Clear). On click it:

1. Reads the current session transcript.
2. Asks the analysis model to summarize it into **one self‑contained continuation prompt**, organized into 7 sections: objective, progress so far, current state, key decisions & rationale, environment & files, open blockers, and next steps.
3. Copies that prompt to the clipboard.
4. Opens a **fresh tab** (same provider) with the prompt **pre‑filled in the input (not auto‑sent)** — you review it and press Enter to continue.

If the AI call is unavailable (spawn error / timeout / non‑zero exit / empty transcript), it falls back to a deterministic structured summary, so it never dead‑ends.

## Flow

```
Compact button
  → postMessage { type: 'compactSession' }
  → MessageHandler / CodexMessageHandler
  → command claudeMirror.compactSession
  → TabManager.compactSession()
       → sourceTab.collectHandoffSnapshot()      (full transcript via ConversationReader)
       → CompactSessionService.build()            (AI summary; heuristic fallback)
       → vscode.env.clipboard.writeText(prompt)
       → createTabForProvider(); setForkInit({ promptText, messages: [] }); startSession()
       → postMessage { type: 'compactSessionResult', ... }  (back to source tab)
  → useClaudeStream clears the button spinner + shows a result toast
```

## Key changes

- **New** `src/extension/session/CompactSessionService.ts` — builds the prompt: transcript (24k‑char budget, head+tail truncation) + a structured grounding capsule (reuses `HandoffContextBuilder`) → `claude -p --model <model>` (90s timeout) → sanitized output. Deterministic fallback via `HandoffPromptComposer`.
- `TabManager.compactSession()` — orchestration (snapshot → build → clipboard → new tab → result), reusing the existing per‑tab handoff lock.
- `commands.ts` — registers `claudeMirror.compactSession` + `runCompactSession()`.
- `MessageHandler.ts` / `CodexMessageHandler.ts` — forward the `compactSession` request to the command; post a failure result on rejection (clears the button state).
- Webview: `InputArea.tsx` (button, handler, result toast, 120s client‑side safety timeout), `store.ts` (`compactingSession` + `compactSessionNotice`), `useClaudeStream.ts` (`compactSessionResult` handling).
- Types: `CompactSessionRequest` (webview→ext) and `CompactSessionResultMessage` (ext→webview).
- Manifest: `claudeMirror.compactSession` command + `claudeMirror.compactSession.model` setting.
- Docs: `COMPACT_SESSION.md` (detail doc), `TECHNICAL.md`, `UI_BUTTONS_AND_COMMANDS.md`, a bilingual Help entry, and `html/compact-session-spec.html`.

## Config

- `claudeMirror.compactSession.model` (default `""` → reuse `claudeMirror.analysisModel`, Haiku by default). Set a Sonnet id for higher‑quality handoffs.

## Verification

- `tsc --noEmit`: clean.
- Full production webpack build: compiled successfully (all bundles).
- Available on Claude and Codex tabs; not on Multi‑Participant tabs.

Branch is off `main` and contains **only** the Compact Session feature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
