### PR TITLE
feat: Bridge Providers — Grok, Antigravity & OpenAI-compatible local models in the model picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -321,6 +321,90 @@
           "default": "happy",
           "description": "Path to the Happy Coder CLI executable"
         },
+        "claudeMirror.bridge.grok.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Bridge Providers: show xAI Grok models in the model picker (requires the official Grok CLI: npm i -g @xai-official/grok, then `grok login`)."
+        },
+        "claudeMirror.bridge.grok.cliPath": {
+          "type": "string",
+          "default": "grok",
+          "description": "Bridge Providers: path to the Grok CLI executable."
+        },
+        "claudeMirror.bridge.grok.models": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "grok-4.5",
+            "grok-composer-2.5-fast"
+          ],
+          "description": "Bridge Providers: Grok model ids offered in the model picker."
+        },
+        "claudeMirror.bridge.antigravity.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Bridge Providers: show Google Antigravity models in the model picker (requires the `agy` CLI, logged in to a Google AI subscription). Note: no streaming — answers appear when the turn completes."
+        },
+        "claudeMirror.bridge.antigravity.cliPath": {
+          "type": "string",
+          "default": "agy",
+          "description": "Bridge Providers: path to the Antigravity CLI executable."
+        },
+        "claudeMirror.bridge.antigravity.models": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "gemini-3.6-flash-medium",
+            "gemini-3.1-pro-high"
+          ],
+          "description": "Bridge Providers: Antigravity model ids offered in the model picker (run `agy models` for the current list)."
+        },
+        "claudeMirror.bridge.openaiProviders": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": [
+              "id",
+              "baseUrl",
+              "models"
+            ],
+            "properties": {
+              "id": {
+                "type": "string",
+                "description": "Short unique id (used in the model value)."
+              },
+              "label": {
+                "type": "string",
+                "description": "Display name in the model picker."
+              },
+              "baseUrl": {
+                "type": "string",
+                "description": "OpenAI-compatible base URL, e.g. http://localhost:11434/v1 (Ollama) or http://localhost:1234/v1 (LM Studio)."
+              },
+              "apiKeyEnv": {
+                "type": "string",
+                "description": "Environment variable holding the API key (optional)."
+              },
+              "apiKeyFile": {
+                "type": "string",
+                "description": "Path to a file whose contents are the API key (optional)."
+              },
+              "models": {
+                "type": "array",
+                "items": {
+                  "type": "string"
+                },
+                "description": "Model ids offered in the model picker."
+              }
+            }
+          },
+          "default": [],
+          "description": "Bridge Providers: OpenAI-compatible endpoints (Ollama, LM Studio, llama.cpp, vLLM, or hosted). Each entry's models appear in the model picker."
+        },
         "claudeMirror.handoff.enabled": {
           "type": "boolean",
           "default": true,

--- a/package.json
+++ b/package.json
@@ -323,8 +323,8 @@
         },
         "claudeMirror.bridge.grok.enabled": {
           "type": "boolean",
-          "default": false,
-          "description": "Bridge Providers: show xAI Grok models in the model picker (requires the official Grok CLI: npm i -g @xai-official/grok, then `grok login`)."
+          "default": true,
+          "description": "Bridge Providers: offer xAI Grok models in the model picker. Models appear only when the Grok CLI is detected on this machine (npm i -g @xai-official/grok, then `grok login`)."
         },
         "claudeMirror.bridge.grok.cliPath": {
           "type": "string",
@@ -344,8 +344,8 @@
         },
         "claudeMirror.bridge.antigravity.enabled": {
           "type": "boolean",
-          "default": false,
-          "description": "Bridge Providers: show Google Antigravity models in the model picker (requires the `agy` CLI, logged in to a Google AI subscription). Note: no streaming — answers appear when the turn completes."
+          "default": true,
+          "description": "Bridge Providers: offer Google Antigravity models in the model picker. Models appear only when the `agy` CLI is detected on this machine (requires a Google AI subscription login). Note: no streaming — answers appear when the turn completes."
         },
         "claudeMirror.bridge.antigravity.cliPath": {
           "type": "string",

--- a/src/bridge-runtime/backends/antigravity.ts
+++ b/src/bridge-runtime/backends/antigravity.ts
@@ -1,0 +1,199 @@
+import { spawn } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { StreamEmitter } from '../protocol';
+import { SessionStore } from '../sessionStore';
+
+/**
+ * Google Antigravity backend via the official `agy` CLI in headless print mode
+ * (`agy -p "<prompt>"`). Requires the user to have installed and authenticated
+ * the Antigravity CLI (Google AI Pro subscription).
+ *
+ * Continuity: agy has no session API in print mode, but it persists every
+ * conversation under ~/.gemini/antigravity-cli/brain/<conversation-id>/ and
+ * accepts `--conversation <id>` to continue one. The bridge snapshots the brain
+ * directory before the first turn, diffs afterwards to learn the new
+ * conversation id, and stores it per ClaUi session for later turns/resumes.
+ *
+ * No streaming: agy prints the final answer only, so the UI shows a working
+ * spinner until the turn completes.
+ */
+
+const AGY_BRAIN_DIR = path.join(os.homedir(), '.gemini', 'antigravity-cli', 'brain');
+const PRINT_TIMEOUT_MS = Number(process.env.CLAUI_BRIDGE_AGY_TIMEOUT_MS || 15 * 60 * 1000);
+
+export function resolveAgyCli(cliPath: string): { command: string; useShell: boolean } {
+  const configured = (cliPath || 'agy').trim();
+  if (path.isAbsolute(configured) && fs.existsSync(configured)) {
+    return { command: configured, useShell: false };
+  }
+  if (process.platform === 'win32' && configured === 'agy') {
+    const localAppData = process.env.LOCALAPPDATA;
+    if (localAppData) {
+      const exe = path.join(localAppData, 'agy', 'bin', 'agy.exe');
+      if (fs.existsSync(exe)) {
+        return { command: exe, useShell: false };
+      }
+    }
+  }
+  return { command: configured, useShell: process.platform === 'win32' };
+}
+
+function listConversationIds(): Set<string> {
+  try {
+    return new Set(fs.readdirSync(AGY_BRAIN_DIR));
+  } catch {
+    return new Set();
+  }
+}
+
+function findNewConversationId(before: Set<string>): string | null {
+  try {
+    const created = fs.readdirSync(AGY_BRAIN_DIR).filter((d) => !before.has(d));
+    if (created.length === 0) return null;
+    if (created.length === 1) return created[0];
+    return created
+      .map((d) => {
+        try {
+          return { d, mtime: fs.statSync(path.join(AGY_BRAIN_DIR, d)).mtimeMs };
+        } catch {
+          return { d, mtime: 0 };
+        }
+      })
+      .sort((a, b) => b.mtime - a.mtime)[0].d;
+  } catch {
+    return null;
+  }
+}
+
+export class AntigravityBackend {
+  private currentChild: ReturnType<typeof spawn> | null = null;
+
+  constructor(
+    private readonly cliPath: string,
+    private readonly model: string,
+    private readonly sessionId: string,
+    private readonly store: SessionStore,
+    private readonly systemPrompt: string,
+    private readonly permissionMode: string,
+    private readonly log: (msg: string) => void,
+  ) {}
+
+  interrupt(): void {
+    try {
+      this.currentChild?.kill();
+    } catch {
+      /* already dead */
+    }
+  }
+
+  private runAgy(promptText: string, conversationId: string | null): Promise<string> {
+    const { command, useShell } = resolveAgyCli(this.cliPath);
+    return new Promise((resolve, reject) => {
+      const argv = [
+        '-p',
+        promptText,
+        '--add-dir',
+        process.cwd(),
+        '--print-timeout',
+        `${Math.max(60, Math.ceil(PRINT_TIMEOUT_MS / 1000))}s`,
+      ];
+      // Mirror ClaUi's permission model: full-access tabs run unattended.
+      if (this.permissionMode !== 'supervised') {
+        argv.push('--dangerously-skip-permissions');
+      }
+      if (this.model) argv.push('--model', this.model);
+      if (conversationId) argv.push('--conversation', conversationId);
+
+      let settled = false;
+      let child: ReturnType<typeof spawn>;
+      try {
+        child = spawn(command, argv, {
+          cwd: process.cwd(),
+          shell: useShell,
+          windowsHide: true,
+        });
+      } catch (e) {
+        reject(e as Error);
+        return;
+      }
+      this.currentChild = child;
+      let stdout = '';
+      let stderr = '';
+      const killTimer = setTimeout(() => {
+        if (!settled) {
+          settled = true;
+          try {
+            child.kill();
+          } catch {
+            /* already dead */
+          }
+          reject(new Error('Antigravity CLI hard-timeout'));
+        }
+      }, PRINT_TIMEOUT_MS + 30000);
+      killTimer.unref?.();
+      child.stdout?.on('data', (d) => {
+        stdout += String(d);
+      });
+      child.stderr?.on('data', (d) => {
+        stderr += String(d);
+        this.log(`agy stderr: ${String(d).slice(0, 400)}`);
+      });
+      child.on('error', (e) => {
+        if (!settled) {
+          settled = true;
+          clearTimeout(killTimer);
+          reject(new Error(`Failed to start Antigravity CLI: ${e.message}. Is agy installed and logged in?`));
+        }
+      });
+      child.on('exit', (code) => {
+        this.currentChild = null;
+        if (settled) return;
+        settled = true;
+        clearTimeout(killTimer);
+        if (code === 0) {
+          resolve(stdout.trim());
+        } else {
+          reject(
+            new Error(`agy exited ${code}: ${(stderr || stdout).slice(0, 800)}`),
+          );
+        }
+      });
+    });
+  }
+
+  async runTurn(prompt: string, emitter: StreamEmitter): Promise<string> {
+    const stored = this.store.read(this.sessionId);
+    const conversationId = stored?.agyConversationId || null;
+    const isFirstTurn = !conversationId;
+
+    let effectivePrompt = prompt;
+    if (isFirstTurn && this.systemPrompt) {
+      effectivePrompt = `<system-rules>\n${this.systemPrompt}\n</system-rules>\n\n${prompt}`;
+    }
+
+    const before = isFirstTurn ? listConversationIds() : null;
+    const answer = await this.runAgy(effectivePrompt, conversationId);
+
+    if (isFirstTurn && before) {
+      const discovered = findNewConversationId(before);
+      if (discovered) {
+        this.store.write(this.sessionId, {
+          backend: 'antigravity',
+          model: this.model,
+          agyConversationId: discovered,
+        });
+        this.log(`agy conversation bound: ${discovered}`);
+      } else {
+        this.log('agy conversation id not discovered; next turn starts fresh context');
+      }
+    }
+    this.store.write(this.sessionId, { backend: 'antigravity', model: this.model });
+    this.store.appendHistory(this.sessionId, 'user', prompt);
+    this.store.appendHistory(this.sessionId, 'assistant', answer);
+
+    emitter.append('text', answer);
+    return answer;
+  }
+}

--- a/src/bridge-runtime/backends/grokAcp.ts
+++ b/src/bridge-runtime/backends/grokAcp.ts
@@ -1,0 +1,342 @@
+import { ChildProcess, spawn } from 'child_process';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as readline from 'readline';
+import { StreamEmitter } from '../protocol';
+import { SessionStore } from '../sessionStore';
+
+/**
+ * xAI Grok backend over the official Grok CLI's ACP surface
+ * (`grok agent stdio`, JSON-RPC / Agent Client Protocol).
+ *
+ * Requires the user to have installed and authenticated the Grok CLI
+ * (`npm i -g @xai-official/grok`, then `grok login`). The bridge advertises no
+ * client fs/terminal capabilities, so Grok uses its own tools; tool activity is
+ * translated into Claude-style tool_use blocks for the ClaUi timeline.
+ */
+
+const KIND_TO_TOOL: Record<string, string> = {
+  execute: 'Bash',
+  edit: 'Edit',
+  read: 'Read',
+  delete: 'Bash',
+  move: 'Bash',
+  search: 'Grep',
+  fetch: 'WebFetch',
+  think: 'Task',
+  other: 'Tool',
+};
+
+/** Resolve a runnable Grok CLI invocation from the configured path. */
+export function resolveGrokCli(cliPath: string): { command: string; useShell: boolean } {
+  const configured = (cliPath || 'grok').trim();
+  if (path.isAbsolute(configured) && fs.existsSync(configured)) {
+    return { command: configured, useShell: false };
+  }
+  if (process.platform === 'win32' && configured === 'grok') {
+    // npm .cmd shims cannot be spawned directly on Windows; prefer the real
+    // binary the shim points at when it is in the standard global location.
+    const appData = process.env.APPDATA;
+    if (appData) {
+      const exe = path.join(
+        appData,
+        'npm',
+        'node_modules',
+        '@xai-official',
+        'grok',
+        'node_modules',
+        '@xai-official',
+        'grok-win32-x64',
+        'bin',
+        'grok.exe',
+      );
+      if (fs.existsSync(exe)) {
+        return { command: exe, useShell: false };
+      }
+    }
+  }
+  // Bare command name: let the shell resolve PATH (handles .cmd shims on win32).
+  return { command: configured, useShell: process.platform === 'win32' };
+}
+
+class AcpClient {
+  private nextId = 1;
+  private pending = new Map<number, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
+  private child: ChildProcess;
+
+  constructor(
+    cliPath: string,
+    private readonly onUpdate: (update: Record<string, unknown>) => void,
+    private readonly log: (msg: string) => void,
+  ) {
+    const { command, useShell } = resolveGrokCli(cliPath);
+    this.child = spawn(command, ['agent', 'stdio'], {
+      cwd: process.cwd(),
+      shell: useShell,
+      windowsHide: true,
+    });
+    this.child.on('error', (e) => this.rejectAll(new Error(`Failed to start Grok CLI: ${e.message}`)));
+    this.child.stderr?.on('data', (d) => this.log(`grok stderr: ${String(d).slice(0, 400)}`));
+    this.child.on('exit', (code) => {
+      this.log(`grok agent exited: ${code}`);
+      this.rejectAll(new Error(`Grok CLI exited (code ${code}). Is it installed and logged in? Run: grok login`));
+    });
+    const rl = readline.createInterface({ input: this.child.stdout! });
+    rl.on('line', (line) => this.onLine(line));
+  }
+
+  private rejectAll(err: Error): void {
+    for (const [, p] of this.pending) p.reject(err);
+    this.pending.clear();
+  }
+
+  private onLine(line: string): void {
+    let msg: {
+      id?: number;
+      result?: unknown;
+      error?: { message?: string };
+      method?: string;
+      params?: {
+        update?: Record<string, unknown>;
+        options?: { kind?: string; optionId?: string }[];
+        toolCall?: { title?: string };
+      };
+    };
+    try {
+      msg = JSON.parse(line);
+    } catch {
+      return;
+    }
+    if (msg.id !== undefined && (msg.result !== undefined || msg.error !== undefined)) {
+      const p = this.pending.get(msg.id);
+      if (p) {
+        this.pending.delete(msg.id);
+        if (msg.error) {
+          p.reject(new Error(msg.error.message || JSON.stringify(msg.error)));
+        } else {
+          p.resolve(msg.result);
+        }
+      }
+      return;
+    }
+    if (msg.method === 'session/update') {
+      this.onUpdate(msg.params?.update || {});
+      return;
+    }
+    if (msg.method === 'session/request_permission' && msg.id !== undefined) {
+      // Mirror ClaUi full-access: auto-approve, preferring an allow-once option.
+      const opts = msg.params?.options || [];
+      const allow =
+        opts.find((o) => o.kind === 'allow_once') ||
+        opts.find((o) => (o.kind || '').startsWith('allow')) ||
+        opts[0];
+      this.send({
+        jsonrpc: '2.0',
+        id: msg.id,
+        result: { outcome: { outcome: 'selected', optionId: allow?.optionId || 'allow' } },
+      });
+      return;
+    }
+    if (msg.method && msg.id !== undefined) {
+      // Unknown agent->client request (e.g. fs/*): refuse politely; Grok falls
+      // back to its own tools since we advertise no client capabilities.
+      this.send({
+        jsonrpc: '2.0',
+        id: msg.id,
+        error: { code: -32601, message: `Method not supported by bridge: ${msg.method}` },
+      });
+    }
+  }
+
+  private send(obj: unknown): void {
+    try {
+      this.child.stdin?.write(JSON.stringify(obj) + '\n');
+    } catch (e) {
+      this.log(`acp write failed: ${(e as Error).message}`);
+    }
+  }
+
+  request(method: string, params: unknown, timeoutMs = 0): Promise<unknown> {
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      this.pending.set(id, { resolve, reject });
+      if (timeoutMs > 0) {
+        const t = setTimeout(() => {
+          if (this.pending.has(id)) {
+            this.pending.delete(id);
+            reject(new Error(`ACP ${method} timed out after ${timeoutMs}ms`));
+          }
+        }, timeoutMs);
+        t.unref?.();
+      }
+      this.send({ jsonrpc: '2.0', id, method, params });
+    });
+  }
+
+  notify(method: string, params: unknown): void {
+    this.send({ jsonrpc: '2.0', method, params });
+  }
+
+  kill(): void {
+    try {
+      this.child.kill();
+    } catch {
+      /* already dead */
+    }
+  }
+}
+
+export class GrokAcpBackend {
+  private acp: AcpClient | null = null;
+  private acpSessionId: string | null = null;
+  private lastText = '';
+  private emitter: StreamEmitter | null = null;
+
+  constructor(
+    private readonly cliPath: string,
+    private readonly model: string,
+    private readonly sessionId: string,
+    private readonly store: SessionStore,
+    private readonly systemPrompt: string,
+    private readonly log: (msg: string) => void,
+  ) {}
+
+  interrupt(): void {
+    if (this.acp && this.acpSessionId) {
+      this.acp.notify('session/cancel', { sessionId: this.acpSessionId });
+    }
+  }
+
+  dispose(): void {
+    this.acp?.kill();
+  }
+
+  private onUpdate = (u: Record<string, unknown>): void => {
+    const emitter = this.emitter;
+    if (!emitter) return;
+    const kind = u.sessionUpdate as string;
+    const content = u.content as { text?: string } | undefined;
+    if (kind === 'agent_thought_chunk') {
+      emitter.append('thinking', content?.text ?? '');
+    } else if (kind === 'agent_message_chunk') {
+      const t = content?.text ?? '';
+      this.lastText += t;
+      emitter.append('text', t);
+    } else if (kind === 'tool_call') {
+      const rawInput = u.rawInput;
+      const input: Record<string, unknown> =
+        rawInput && typeof rawInput === 'object'
+          ? (rawInput as Record<string, unknown>)
+          : { description: (u.title as string) || '' };
+      let name = KIND_TO_TOOL[(u.kind as string) || ''] || '';
+      if (!name || name === 'Tool') {
+        if (input.command) name = 'Bash';
+        else if (input.file_path !== undefined && input.content !== undefined) name = 'Write';
+        else if (input.target_file || input.file_path) name = 'Read';
+        else if (input.pattern || input.query) name = 'Grep';
+        else if (input.url) name = 'WebFetch';
+        else name = 'Tool';
+      }
+      if (u.title && !input.description && name !== 'Bash') {
+        input.description = u.title;
+      }
+      emitter.toolUse(String(u.toolCallId || `tool_${Date.now()}`), name, input);
+    } else if (kind === 'tool_call_update') {
+      const status = u.status as string;
+      if (status === 'completed' || status === 'failed') {
+        const parts: string[] = [];
+        const contentArr = u.content as unknown[] | undefined;
+        if (Array.isArray(contentArr)) {
+          for (const c of contentArr) {
+            const cc = c as { type?: string; content?: { type?: string; text?: string }; path?: string };
+            if (cc?.type === 'content' && cc.content?.type === 'text' && cc.content.text) {
+              parts.push(cc.content.text);
+            } else if (cc?.type === 'diff') {
+              parts.push(`[diff] ${cc.path || ''}`);
+            } else if (cc?.type === 'terminal') {
+              parts.push('[terminal output]');
+            }
+          }
+        }
+        emitter.toolResult(
+          String(u.toolCallId || ''),
+          parts.join('\n') || (status === 'failed' ? 'failed' : 'done'),
+          status === 'failed',
+        );
+      }
+    } else if (kind === 'plan') {
+      const entries = ((u.entries as { content?: string }[]) || [])
+        .map((e, i) => `${i + 1}. ${e.content || ''}`)
+        .join('\n');
+      if (entries) emitter.append('thinking', `Plan:\n${entries}\n`);
+    }
+  };
+
+  private async ensureSession(): Promise<void> {
+    if (this.acp && this.acpSessionId) return;
+    this.acp = new AcpClient(this.cliPath, this.onUpdate, this.log);
+    await this.acp.request(
+      'initialize',
+      {
+        protocolVersion: 1,
+        clientCapabilities: {},
+        clientInfo: { name: 'claui-bridge', version: '1.0.0' },
+      },
+      30000,
+    );
+
+    const stored = this.store.read(this.sessionId);
+    if (stored?.grokSessionId) {
+      try {
+        await this.acp.request(
+          'session/load',
+          { sessionId: stored.grokSessionId, cwd: process.cwd(), mcpServers: [] },
+          120000,
+        );
+        this.acpSessionId = stored.grokSessionId;
+      } catch (e) {
+        this.log(`session/load failed, starting new: ${(e as Error).message}`);
+      }
+    }
+    if (!this.acpSessionId) {
+      const res = (await this.acp.request(
+        'session/new',
+        { cwd: process.cwd(), mcpServers: [] },
+        60000,
+      )) as { sessionId?: string };
+      this.acpSessionId = res.sessionId || null;
+      if (!this.acpSessionId) {
+        throw new Error('Grok CLI did not return a session id');
+      }
+    }
+    this.store.write(this.sessionId, {
+      backend: 'grok',
+      model: this.model,
+      grokSessionId: this.acpSessionId,
+    });
+  }
+
+  async runTurn(prompt: string, emitter: StreamEmitter): Promise<string> {
+    await this.ensureSession();
+    this.emitter = emitter;
+    this.lastText = '';
+
+    const promptBlocks: { type: 'text'; text: string }[] = [];
+    if (this.systemPrompt && !this.store.read(this.sessionId)?.history?.length) {
+      promptBlocks.push({ type: 'text', text: `<system-rules>\n${this.systemPrompt}\n</system-rules>` });
+    }
+    promptBlocks.push({ type: 'text', text: prompt });
+
+    const res = (await this.acp!.request('session/prompt', {
+      sessionId: this.acpSessionId,
+      prompt: promptBlocks,
+    })) as { stopReason?: string } | undefined;
+
+    this.store.appendHistory(this.sessionId, 'user', prompt);
+    if (this.lastText) {
+      this.store.appendHistory(this.sessionId, 'assistant', this.lastText);
+    }
+    void res;
+    return this.lastText;
+  }
+}

--- a/src/bridge-runtime/backends/openaiCompat.ts
+++ b/src/bridge-runtime/backends/openaiCompat.ts
@@ -1,0 +1,156 @@
+import * as http from 'http';
+import * as https from 'https';
+import { URL } from 'url';
+import { OpenAiCompatProvider, resolveOpenAiApiKey } from '../config';
+import { StreamEmitter } from '../protocol';
+import { SessionStore } from '../sessionStore';
+
+/**
+ * OpenAI-compatible chat backend (Ollama, LM Studio, llama.cpp llama-server,
+ * vLLM, or any hosted endpoint speaking /v1/chat/completions).
+ *
+ * The server is stateless, so the bridge owns the conversation history and
+ * replays it on every turn (persisted per ClaUi session in the SessionStore).
+ * Responses stream via SSE and are forwarded as text deltas.
+ */
+export class OpenAiCompatBackend {
+  private aborter: AbortController | null = null;
+
+  constructor(
+    private readonly provider: OpenAiCompatProvider,
+    private readonly model: string,
+    private readonly sessionId: string,
+    private readonly store: SessionStore,
+    private readonly systemPrompt: string,
+  ) {}
+
+  interrupt(): void {
+    this.aborter?.abort();
+  }
+
+  async runTurn(prompt: string, emitter: StreamEmitter): Promise<string> {
+    const state = this.store.read(this.sessionId);
+    const history = state?.history || [];
+    const messages: { role: string; content: string }[] = [];
+    if (this.systemPrompt) {
+      messages.push({ role: 'system', content: this.systemPrompt });
+    }
+    for (const turn of history) {
+      messages.push({ role: turn.role, content: turn.content });
+    }
+    messages.push({ role: 'user', content: prompt });
+
+    const text = await this.streamChatCompletion(messages, (delta) =>
+      emitter.append('text', delta),
+    );
+
+    this.store.write(this.sessionId, { backend: 'openai', model: this.model });
+    this.store.appendHistory(this.sessionId, 'user', prompt);
+    this.store.appendHistory(this.sessionId, 'assistant', text);
+    return text;
+  }
+
+  private streamChatCompletion(
+    messages: { role: string; content: string }[],
+    onDelta: (text: string) => void,
+  ): Promise<string> {
+    const endpoint = new URL(
+      this.provider.baseUrl.replace(/\/+$/, '') + '/chat/completions',
+    );
+    const body = JSON.stringify({
+      model: this.model,
+      messages,
+      stream: true,
+    });
+    const apiKey = resolveOpenAiApiKey(this.provider);
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+      'Content-Length': String(Buffer.byteLength(body)),
+      Accept: 'text/event-stream',
+    };
+    if (apiKey) headers.Authorization = `Bearer ${apiKey}`;
+
+    this.aborter = new AbortController();
+    const transport = endpoint.protocol === 'https:' ? https : http;
+
+    return new Promise<string>((resolve, reject) => {
+      const req = transport.request(
+        endpoint,
+        { method: 'POST', headers, signal: this.aborter!.signal },
+        (res) => {
+          if (!res.statusCode || res.statusCode >= 400) {
+            let errBody = '';
+            res.on('data', (d) => {
+              errBody += String(d);
+            });
+            res.on('end', () =>
+              reject(
+                new Error(
+                  `${endpoint.host} returned HTTP ${res.statusCode}: ${errBody.slice(0, 500)}`,
+                ),
+              ),
+            );
+            return;
+          }
+
+          let full = '';
+          let buffer = '';
+          let sawDone = false;
+
+          const handleDataLine = (payload: string) => {
+            if (payload === '[DONE]') {
+              sawDone = true;
+              return;
+            }
+            try {
+              const parsed = JSON.parse(payload) as {
+                choices?: { delta?: { content?: string }; message?: { content?: string } }[];
+              };
+              const choice = parsed.choices?.[0];
+              const delta = choice?.delta?.content ?? choice?.message?.content ?? '';
+              if (delta) {
+                full += delta;
+                onDelta(delta);
+              }
+            } catch {
+              /* ignore malformed SSE payloads */
+            }
+          };
+
+          res.setEncoding('utf8');
+          res.on('data', (chunk: string) => {
+            buffer += chunk;
+            let nl: number;
+            while ((nl = buffer.indexOf('\n')) >= 0) {
+              const line = buffer.slice(0, nl).replace(/\r$/, '');
+              buffer = buffer.slice(nl + 1);
+              if (line.startsWith('data:')) {
+                handleDataLine(line.slice(5).trim());
+              } else if (line.trim() && !full && !sawDone && line.trim().startsWith('{')) {
+                // Non-streaming server that ignored stream:true — parse whole body.
+                handleDataLine(line.trim());
+              }
+            }
+          });
+          res.on('end', () => resolve(full));
+          res.on('error', (e) => reject(e));
+        },
+      );
+      req.on('error', (e: NodeJS.ErrnoException) => {
+        if (e.name === 'AbortError') {
+          reject(new Error('Request interrupted'));
+        } else if (e.code === 'ECONNREFUSED') {
+          reject(
+            new Error(
+              `Cannot reach ${endpoint.host} — is the server running? (${this.provider.baseUrl})`,
+            ),
+          );
+        } else {
+          reject(e);
+        }
+      });
+      req.write(body);
+      req.end();
+    });
+  }
+}

--- a/src/bridge-runtime/cli.ts
+++ b/src/bridge-runtime/cli.ts
@@ -1,0 +1,192 @@
+import { randomUUID } from 'crypto';
+import * as fs from 'fs';
+import * as path from 'path';
+import { AntigravityBackend } from './backends/antigravity';
+import { GrokAcpBackend } from './backends/grokAcp';
+import { OpenAiCompatBackend } from './backends/openaiCompat';
+import {
+  BridgeModelRef,
+  CLAUI_HOME,
+  loadBridgeConfig,
+  parseBridgeModel,
+  storageDir,
+} from './config';
+import { attachStdin, StreamEmitter } from './protocol';
+import { SessionStore } from './sessionStore';
+
+/**
+ * ClaUi bridge runtime — a drop-in stand-in for the claude CLI that routes
+ * conversations to non-Claude backends (xAI Grok, Google Antigravity, or any
+ * OpenAI-compatible server) while speaking the exact stream-json protocol the
+ * extension already understands.
+ *
+ * ClaUi spawns this instead of the claude CLI for bridge-provider tabs (the
+ * same mechanism as the Happy/remote provider): all standard claude flags are
+ * accepted; the backend is selected by the namespaced --model value
+ * (`bridge:grok/<model>`, `bridge:antigravity/<model>`,
+ * `bridge:openai/<providerId>/<model>`), with a sticky per-session fallback so
+ * resumed tabs keep their backend even if the flag is missing.
+ */
+
+const args = process.argv.slice(2);
+
+function flagValue(name: string): string | null {
+  const i = args.indexOf(name);
+  return i >= 0 && i + 1 < args.length ? args[i + 1] : null;
+}
+
+const LOG_FILE = path.join(CLAUI_HOME, 'bridge.log');
+function log(...parts: unknown[]): void {
+  try {
+    fs.mkdirSync(CLAUI_HOME, { recursive: true });
+    fs.appendFileSync(
+      LOG_FILE,
+      `[${new Date().toISOString()}] ${parts.map((p) => String(p)).join(' ')}\n`,
+    );
+  } catch {
+    /* logging must never break the bridge */
+  }
+}
+
+interface Backend {
+  runTurn(prompt: string, emitter: StreamEmitter): Promise<string>;
+  interrupt(): void;
+  dispose?(): void;
+}
+
+async function main(): Promise<void> {
+  const config = loadBridgeConfig();
+  const store = new SessionStore(storageDir(config));
+
+  const resumeId = flagValue('--resume');
+  const sessionId = resumeId || flagValue('--session-id') || randomUUID();
+  const requestedModel = flagValue('--model') || '';
+  const permissionMode =
+    flagValue('--permission-mode') === 'bypassPermissions' ? 'full-access' : 'supervised';
+  const systemPrompt = flagValue('--append-system-prompt') || '';
+
+  // Backend selection: explicit namespaced --model wins; otherwise a resumed
+  // session sticks to its stored backend+model.
+  let ref: BridgeModelRef | null = parseBridgeModel(requestedModel);
+  if (!ref && resumeId) {
+    const stored = store.read(sessionId);
+    if (stored?.backend && stored.model) {
+      if (stored.backend === 'openai') {
+        if (stored.openaiProviderId) {
+          ref = { backend: 'openai', providerId: stored.openaiProviderId, model: stored.model };
+        }
+      } else if (stored.backend === 'grok' || stored.backend === 'antigravity') {
+        ref = { backend: stored.backend, model: stored.model };
+      }
+    }
+  }
+
+  log('bridge start', JSON.stringify({ sessionId, requestedModel, resume: !!resumeId }));
+
+  const displayModel = ref
+    ? ref.backend === 'openai'
+      ? `${ref.providerId}/${ref.model}`
+      : `${ref.backend}/${ref.model}`
+    : requestedModel || 'bridge';
+  const emitter = new StreamEmitter(sessionId, displayModel);
+  emitter.init(process.cwd(), flagValue('--permission-mode') || 'default');
+
+  if (!ref) {
+    const startedAt = Date.now();
+    emitter.error(
+      'ClaUi bridge: no backend selected. Pick a bridge model from the model ' +
+        'picker (values look like bridge:grok/…, bridge:antigravity/…, ' +
+        'bridge:openai/<provider>/…), or check ~/.claui/bridge.json.',
+      startedAt,
+    );
+    process.exit(1);
+  }
+
+  let backend: Backend;
+  if (ref.backend === 'grok') {
+    backend = new GrokAcpBackend(
+      config.grok?.cliPath || 'grok',
+      ref.model,
+      sessionId,
+      store,
+      systemPrompt,
+      log,
+    );
+  } else if (ref.backend === 'antigravity') {
+    backend = new AntigravityBackend(
+      config.antigravity?.cliPath || 'agy',
+      ref.model,
+      sessionId,
+      store,
+      systemPrompt,
+      permissionMode,
+      log,
+    );
+  } else {
+    const provider = (config.openai || []).find((p) => p.id === ref!.providerId);
+    if (!provider) {
+      const startedAt = Date.now();
+      emitter.error(
+        `ClaUi bridge: unknown OpenAI-compatible provider "${ref.providerId}". ` +
+          'Check the claudeMirror.bridge.openaiProviders setting.',
+        startedAt,
+      );
+      process.exit(1);
+      return;
+    }
+    backend = new OpenAiCompatBackend(provider, ref.model, sessionId, store, systemPrompt);
+    store.write(sessionId, {
+      backend: 'openai',
+      model: ref.model,
+      openaiProviderId: ref.providerId,
+    });
+  }
+
+  // --- Turn loop -----------------------------------------------------------
+  const queue: string[] = [];
+  let running = false;
+  let stdinClosed = false;
+
+  async function pump(): Promise<void> {
+    if (running) return;
+    if (queue.length === 0) {
+      if (stdinClosed) {
+        backend.dispose?.();
+        process.exit(0);
+      }
+      return;
+    }
+    running = true;
+    const prompt = queue.shift()!;
+    const startedAt = Date.now();
+    try {
+      const text = await backend.runTurn(prompt, emitter);
+      emitter.result({ text, startedAt });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      log('turn error:', message);
+      emitter.error(`Bridge (${ref!.backend}) error: ${message}`, startedAt);
+    }
+    running = false;
+    void pump();
+  }
+
+  attachStdin({
+    onPrompt: (text) => {
+      queue.push(text);
+      void pump();
+    },
+    onInterrupt: () => backend.interrupt(),
+    onClose: () => {
+      stdinClosed = true;
+      void pump();
+    },
+  });
+
+  process.on('exit', () => backend.dispose?.());
+}
+
+void main().catch((e) => {
+  log('fatal:', e instanceof Error ? e.stack || e.message : String(e));
+  process.exit(1);
+});

--- a/src/bridge-runtime/config.ts
+++ b/src/bridge-runtime/config.ts
@@ -1,0 +1,97 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+/** OpenAI-compatible endpoint profile (Ollama / LM Studio / llama.cpp / vLLM / any). */
+export interface OpenAiCompatProvider {
+  id: string;
+  label?: string;
+  baseUrl: string;
+  /** Direct API key (discouraged — prefer apiKeyEnv/apiKeyFile). */
+  apiKey?: string;
+  /** Name of an environment variable holding the API key. */
+  apiKeyEnv?: string;
+  /** Path to a file whose trimmed contents are the API key. */
+  apiKeyFile?: string;
+  models?: string[];
+}
+
+export interface BridgeConfig {
+  version: number;
+  grok?: { cliPath?: string };
+  antigravity?: { cliPath?: string };
+  openai?: OpenAiCompatProvider[];
+  /** Directory for bridge session state (defaults to ~/.claui/bridge-sessions). */
+  storageDir?: string;
+  /** ClaUi permission mode at spawn time ('full-access' | 'supervised'). */
+  permissionMode?: string;
+}
+
+export const CLAUI_HOME = path.join(os.homedir(), '.claui');
+export const CONFIG_PATH =
+  process.env.CLAUI_BRIDGE_CONFIG || path.join(CLAUI_HOME, 'bridge.json');
+
+export function loadBridgeConfig(): BridgeConfig {
+  try {
+    const raw = fs.readFileSync(CONFIG_PATH, 'utf8');
+    const parsed = JSON.parse(raw) as BridgeConfig;
+    if (parsed && typeof parsed === 'object') {
+      return parsed;
+    }
+  } catch {
+    /* missing/corrupt config falls through to defaults */
+  }
+  return { version: 1 };
+}
+
+export function storageDir(cfg: BridgeConfig): string {
+  return cfg.storageDir || path.join(CLAUI_HOME, 'bridge-sessions');
+}
+
+export function resolveOpenAiApiKey(p: OpenAiCompatProvider): string {
+  if (p.apiKey) return p.apiKey.trim();
+  if (p.apiKeyEnv && process.env[p.apiKeyEnv]) {
+    return String(process.env[p.apiKeyEnv]).trim();
+  }
+  if (p.apiKeyFile) {
+    try {
+      return fs.readFileSync(p.apiKeyFile, 'utf8').trim();
+    } catch {
+      return '';
+    }
+  }
+  return '';
+}
+
+/** Parsed form of a ClaUi bridge model value (`bridge:<backend>/<rest>`). */
+export interface BridgeModelRef {
+  backend: 'grok' | 'antigravity' | 'openai';
+  /** Backend model id (for openai this is the part after the provider id). */
+  model: string;
+  /** Only for openai backend: the provider profile id. */
+  providerId?: string;
+}
+
+export const BRIDGE_MODEL_PREFIX = 'bridge:';
+
+export function parseBridgeModel(value: string | null | undefined): BridgeModelRef | null {
+  const v = String(value || '').trim();
+  if (!v.startsWith(BRIDGE_MODEL_PREFIX)) return null;
+  const rest = v.slice(BRIDGE_MODEL_PREFIX.length);
+  const slash = rest.indexOf('/');
+  if (slash < 0) return null;
+  const backend = rest.slice(0, slash);
+  const tail = rest.slice(slash + 1);
+  if (backend === 'grok') return { backend, model: tail };
+  if (backend === 'antigravity') return { backend, model: tail };
+  if (backend === 'openai') {
+    const slash2 = tail.indexOf('/');
+    if (slash2 < 0) return null;
+    return {
+      backend,
+      providerId: tail.slice(0, slash2),
+      model: tail.slice(slash2 + 1),
+    };
+  }
+  return null;
+}

--- a/src/bridge-runtime/protocol.ts
+++ b/src/bridge-runtime/protocol.ts
@@ -1,0 +1,273 @@
+import { randomUUID } from 'crypto';
+import * as readline from 'readline';
+
+/**
+ * Claude-CLI stream-json protocol emitter.
+ *
+ * The bridge process impersonates the claude CLI towards ClaUi: it emits the
+ * same `system/init`, `stream_event`, `assistant` and `result` messages the
+ * real CLI produces with `--output-format stream-json --include-partial-messages`,
+ * so the whole webview pipeline (streaming text, thinking blocks, tool chips)
+ * works unchanged against non-Claude backends.
+ */
+export class StreamEmitter {
+  private msg: {
+    id: string;
+    blocks: { type: 'thinking' | 'text'; content: string }[];
+    openIndex: number;
+  } | null = null;
+
+  constructor(
+    public readonly sessionId: string,
+    public readonly model: string,
+  ) {}
+
+  out(obj: unknown): void {
+    process.stdout.write(JSON.stringify(obj) + '\n');
+  }
+
+  private streamEvent(event: unknown): void {
+    this.out({
+      type: 'stream_event',
+      event,
+      session_id: this.sessionId,
+      parent_tool_use_id: null,
+      uuid: randomUUID(),
+    });
+  }
+
+  /** ClaUi expects an init event first, exactly like the real CLI. */
+  init(cwd: string, permissionMode: string): void {
+    this.out({
+      type: 'system',
+      subtype: 'init',
+      cwd,
+      session_id: this.sessionId,
+      tools: [],
+      mcp_servers: [],
+      model: this.model,
+      permissionMode: permissionMode || 'default',
+      slash_commands: [],
+      apiKeySource: 'none',
+      output_style: 'default',
+      agents: [],
+      uuid: randomUUID(),
+    });
+  }
+
+  private ensureMessage(): void {
+    if (this.msg) return;
+    this.msg = { id: `msg_bridge_${randomUUID().slice(0, 12)}`, blocks: [], openIndex: -1 };
+    this.streamEvent({
+      type: 'message_start',
+      message: {
+        id: this.msg.id,
+        type: 'message',
+        role: 'assistant',
+        model: this.model,
+        content: [],
+        stop_reason: null,
+        stop_sequence: null,
+        usage: { input_tokens: 0, output_tokens: 0 },
+      },
+    });
+  }
+
+  private closeOpenBlock(): void {
+    if (this.msg && this.msg.openIndex >= 0) {
+      this.streamEvent({ type: 'content_block_stop', index: this.msg.openIndex });
+      this.msg.openIndex = -1;
+    }
+  }
+
+  /** Append streamed output. kind 'thinking' renders as a thinking block. */
+  append(kind: 'thinking' | 'text', data: string): void {
+    if (!data) return;
+    this.ensureMessage();
+    const m = this.msg!;
+    const last = m.blocks[m.blocks.length - 1];
+    if (!last || last.type !== kind || m.openIndex < 0) {
+      this.closeOpenBlock();
+      m.blocks.push({ type: kind, content: '' });
+      m.openIndex = m.blocks.length - 1;
+      this.streamEvent({
+        type: 'content_block_start',
+        index: m.openIndex,
+        content_block:
+          kind === 'thinking'
+            ? { type: 'thinking', thinking: '', signature: '' }
+            : { type: 'text', text: '' },
+      });
+    }
+    m.blocks[m.blocks.length - 1].content += data;
+    this.streamEvent({
+      type: 'content_block_delta',
+      index: m.openIndex,
+      delta:
+        kind === 'thinking'
+          ? { type: 'thinking_delta', thinking: data }
+          : { type: 'text_delta', text: data },
+    });
+  }
+
+  /** Emit a standalone assistant message carrying a tool_use block (closes any
+   *  streamed message first with stop_reason tool_use, like the real CLI). */
+  toolUse(toolCallId: string, name: string, input: Record<string, unknown>): void {
+    this.finishMessage('tool_use');
+    this.out({
+      type: 'assistant',
+      message: {
+        id: `msg_bridge_${randomUUID().slice(0, 12)}`,
+        type: 'message',
+        role: 'assistant',
+        model: this.model,
+        content: [{ type: 'tool_use', id: toolCallId, name, input }],
+        stop_reason: 'tool_use',
+        stop_sequence: null,
+        usage: { input_tokens: 0, output_tokens: 0 },
+      },
+      session_id: this.sessionId,
+      parent_tool_use_id: null,
+      uuid: randomUUID(),
+    });
+  }
+
+  /** Tool results flow back as user-role tool_result messages. */
+  toolResult(toolCallId: string, content: string, isError = false): void {
+    this.out({
+      type: 'user',
+      message: {
+        role: 'user',
+        content: [
+          {
+            type: 'tool_result',
+            tool_use_id: toolCallId,
+            content: [{ type: 'text', text: content }],
+            is_error: isError,
+          },
+        ],
+      },
+      session_id: this.sessionId,
+      parent_tool_use_id: null,
+      uuid: randomUUID(),
+    });
+  }
+
+  /** Close the current streamed message and emit its full assistant echo. */
+  finishMessage(stopReason: string): void {
+    if (!this.msg) return;
+    this.closeOpenBlock();
+    this.streamEvent({
+      type: 'message_delta',
+      delta: { stop_reason: stopReason, stop_sequence: null },
+      usage: { output_tokens: 0 },
+    });
+    this.streamEvent({ type: 'message_stop' });
+    const content = this.msg.blocks.map((b) =>
+      b.type === 'thinking'
+        ? { type: 'thinking', thinking: b.content, signature: '' }
+        : { type: 'text', text: b.content },
+    );
+    this.out({
+      type: 'assistant',
+      message: {
+        id: this.msg.id,
+        type: 'message',
+        role: 'assistant',
+        model: this.model,
+        content: content.length ? content : [{ type: 'text', text: '' }],
+        stop_reason: stopReason,
+        stop_sequence: null,
+        usage: { input_tokens: 0, output_tokens: 0 },
+      },
+      session_id: this.sessionId,
+      parent_tool_use_id: null,
+      uuid: randomUUID(),
+    });
+    this.msg = null;
+  }
+
+  result(opts: { text: string; startedAt: number; stopReason?: string }): void {
+    this.finishMessage('end_turn');
+    this.out({
+      type: 'result',
+      subtype: 'success',
+      is_error: false,
+      result: opts.text,
+      session_id: this.sessionId,
+      duration_ms: Date.now() - opts.startedAt,
+      duration_api_ms: Date.now() - opts.startedAt,
+      num_turns: 1,
+      usage: { input_tokens: 0, output_tokens: 0 },
+      total_cost_usd: 0,
+      uuid: randomUUID(),
+      stop_reason: opts.stopReason || 'end_turn',
+    });
+  }
+
+  error(message: string, startedAt: number): void {
+    this.finishMessage('end_turn');
+    this.out({
+      type: 'result',
+      subtype: 'error_during_execution',
+      is_error: true,
+      result: message,
+      session_id: this.sessionId,
+      duration_ms: Date.now() - startedAt,
+      duration_api_ms: 0,
+      num_turns: 1,
+      usage: { input_tokens: 0, output_tokens: 0 },
+      total_cost_usd: 0,
+      uuid: randomUUID(),
+    });
+  }
+}
+
+export interface StdinHandlers {
+  onPrompt: (text: string) => void;
+  onInterrupt: () => void;
+  onClose: () => void;
+}
+
+function extractText(message: unknown): string {
+  const m = message as { content?: unknown } | undefined;
+  const c = m?.content;
+  if (typeof c === 'string') return c;
+  if (Array.isArray(c)) {
+    return c
+      .map((b) => (b && (b as { type?: string }).type === 'text' ? (b as { text?: string }).text || '' : ''))
+      .filter(Boolean)
+      .join('\n');
+  }
+  return '';
+}
+
+/** Wire ClaUi's stream-json stdin: user prompts + control requests. */
+export function attachStdin(handlers: StdinHandlers): void {
+  const rl = readline.createInterface({ input: process.stdin });
+  rl.on('line', (line) => {
+    if (!line.trim()) return;
+    let m: { type?: string; message?: unknown; request_id?: unknown; request?: { subtype?: string } };
+    try {
+      m = JSON.parse(line);
+    } catch {
+      return;
+    }
+    if (m.type === 'user') {
+      const prompt = extractText(m.message);
+      if (prompt) handlers.onPrompt(prompt);
+    } else if (m.type === 'control_request') {
+      if (m.request?.subtype === 'interrupt') {
+        handlers.onInterrupt();
+      }
+      // Acknowledge every control request so the CLI-side await resolves.
+      process.stdout.write(
+        JSON.stringify({
+          type: 'control_response',
+          response: { subtype: 'success', request_id: m.request_id },
+        }) + '\n',
+      );
+    }
+  });
+  rl.on('close', handlers.onClose);
+}

--- a/src/bridge-runtime/sessionStore.ts
+++ b/src/bridge-runtime/sessionStore.ts
@@ -1,0 +1,69 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+/**
+ * Durable per-tab bridge session state, keyed by the ClaUi session UUID.
+ *
+ * ClaUi resumes tabs with `--resume <uuid>`; the bridge maps that UUID to its
+ * backend-native continuation handle (grok ACP session id, antigravity
+ * conversation id, or the stored OpenAI-compatible chat history) so a tab
+ * keeps its context across process restarts and window reloads.
+ */
+export interface BridgeSessionState {
+  backend: string;
+  model: string;
+  /** grok: ACP session id to session/load on resume. */
+  grokSessionId?: string;
+  /** antigravity: conversation id passed back via --conversation. */
+  agyConversationId?: string;
+  /** openai: which configured provider profile this session is bound to. */
+  openaiProviderId?: string;
+  /** openai: full chat history (the server is stateless). */
+  history?: { role: 'user' | 'assistant'; content: string }[];
+  updatedAt?: string;
+}
+
+export class SessionStore {
+  constructor(private readonly dir: string) {}
+
+  private fileFor(sessionId: string): string {
+    // Session ids come from ClaUi as UUIDs; keep a strict basename guard anyway.
+    const safe = String(sessionId).replace(/[^a-zA-Z0-9._-]/g, '_');
+    return path.join(this.dir, `${safe}.json`);
+  }
+
+  read(sessionId: string): BridgeSessionState | null {
+    try {
+      const raw = fs.readFileSync(this.fileFor(sessionId), 'utf8');
+      const parsed = JSON.parse(raw) as BridgeSessionState;
+      return parsed && typeof parsed === 'object' ? parsed : null;
+    } catch {
+      return null;
+    }
+  }
+
+  write(sessionId: string, patch: Partial<BridgeSessionState>): void {
+    try {
+      fs.mkdirSync(this.dir, { recursive: true });
+      const prev = this.read(sessionId) || ({} as BridgeSessionState);
+      const next = { ...prev, ...patch, updatedAt: new Date().toISOString() };
+      const file = this.fileFor(sessionId);
+      const tmp = `${file}.tmp`;
+      fs.writeFileSync(tmp, JSON.stringify(next, null, 2));
+      fs.renameSync(tmp, file);
+    } catch {
+      /* session persistence is best-effort; a failed write only loses resume */
+    }
+  }
+
+  appendHistory(sessionId: string, role: 'user' | 'assistant', content: string): void {
+    const prev = this.read(sessionId);
+    const history = prev?.history ? [...prev.history] : [];
+    history.push({ role, content });
+    // Bound the stored transcript so a long-lived tab cannot grow unbounded.
+    const MAX_TURNS = 200;
+    this.write(sessionId, {
+      history: history.length > MAX_TURNS ? history.slice(-MAX_TURNS) : history,
+    });
+  }
+}

--- a/src/extension/bridge/BridgeProviderService.ts
+++ b/src/extension/bridge/BridgeProviderService.ts
@@ -1,0 +1,181 @@
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import * as vscode from 'vscode';
+
+/**
+ * Bridge Providers — drive non-Claude backends (xAI Grok, Google Antigravity,
+ * any OpenAI-compatible server) through ordinary Claude tabs.
+ *
+ * Mechanism: the same cliPathOverride seam used by the Happy/remote provider.
+ * For a bridge model the tab spawns the bundled bridge runtime
+ * (dist/bridge-runtime/cli.js) instead of the claude CLI; the runtime speaks
+ * claude stream-json to the extension and talks to the selected backend behind
+ * it. Backend/model selection travels in the --model value, namespaced as
+ * `bridge:<backend>/<model>` (see src/bridge-runtime/config.ts).
+ *
+ * The runtime cannot read VS Code settings, so this service mirrors the
+ * claudeMirror.bridge.* settings into ~/.claui/bridge.json on activation and
+ * on every configuration change.
+ */
+
+export const BRIDGE_MODEL_PREFIX = 'bridge:';
+/** Marker every bridge cliPathOverride contains — used to recognize bridge
+ *  tabs in snapshots even across extension updates (the absolute path moves). */
+const BRIDGE_CLI_MARKER = `bridge-runtime${path.sep}cli.js`;
+
+export interface BridgeModelOption {
+  label: string;
+  value: string;
+}
+
+interface OpenAiProviderSetting {
+  id?: string;
+  label?: string;
+  baseUrl?: string;
+  apiKey?: string;
+  apiKeyEnv?: string;
+  apiKeyFile?: string;
+  models?: string[];
+}
+
+export function isBridgeModelValue(value: string | null | undefined): boolean {
+  return !!value && String(value).startsWith(BRIDGE_MODEL_PREFIX);
+}
+
+/** Backend segment of a bridge model value ('grok' | 'antigravity' | 'openai/<id>'). */
+export function bridgeBackendKey(value: string | null | undefined): string {
+  if (!isBridgeModelValue(value)) return '';
+  const rest = String(value).slice(BRIDGE_MODEL_PREFIX.length);
+  const parts = rest.split('/');
+  if (parts[0] === 'openai') {
+    return parts.length > 1 ? `openai/${parts[1]}` : 'openai';
+  }
+  return parts[0] || '';
+}
+
+export function isBridgeCliCommand(command: string | null | undefined): boolean {
+  return !!command && String(command).includes(BRIDGE_CLI_MARKER);
+}
+
+export class BridgeProviderService {
+  private static instance: BridgeProviderService | null = null;
+
+  static init(context: vscode.ExtensionContext): BridgeProviderService {
+    if (!this.instance) {
+      this.instance = new BridgeProviderService(context);
+      this.instance.syncConfigFile();
+      context.subscriptions.push(
+        vscode.workspace.onDidChangeConfiguration((e) => {
+          if (e.affectsConfiguration('claudeMirror.bridge') ||
+              e.affectsConfiguration('claudeMirror.permissionMode')) {
+            this.instance?.syncConfigFile();
+          }
+        }),
+      );
+    }
+    return this.instance;
+  }
+
+  static get(): BridgeProviderService | null {
+    return this.instance;
+  }
+
+  private constructor(private readonly context: vscode.ExtensionContext) {}
+
+  /** Command string spawned instead of the claude CLI for bridge tabs.
+   *  ClaudeProcessManager spawns through a shell, so an embedded quoted path
+   *  is safe. Requires `node` on PATH (same class of requirement as the other
+   *  provider CLIs this feature drives). */
+  cliCommand(): string {
+    const bridgePath = path.join(
+      this.context.extensionPath,
+      'dist',
+      'bridge-runtime',
+      'cli.js',
+    );
+    return `node "${bridgePath}"`;
+  }
+
+  private config() {
+    return vscode.workspace.getConfiguration('claudeMirror');
+  }
+
+  private openAiProviders(): OpenAiProviderSetting[] {
+    const raw = this.config().get<OpenAiProviderSetting[]>('bridge.openaiProviders', []);
+    return Array.isArray(raw)
+      ? raw.filter((p) => p && typeof p.id === 'string' && typeof p.baseUrl === 'string')
+      : [];
+  }
+
+  /** Mirror settings into ~/.claui/bridge.json for the bridge runtime. */
+  syncConfigFile(): void {
+    try {
+      const cfg = this.config();
+      const clauiHome = path.join(os.homedir(), '.claui');
+      const storageDir = path.join(
+        this.context.globalStorageUri?.fsPath || clauiHome,
+        'bridge-sessions',
+      );
+      const payload = {
+        version: 1,
+        grok: { cliPath: cfg.get<string>('bridge.grok.cliPath', 'grok') },
+        antigravity: { cliPath: cfg.get<string>('bridge.antigravity.cliPath', 'agy') },
+        openai: this.openAiProviders(),
+        storageDir,
+        permissionMode: cfg.get<string>('permissionMode', 'full-access'),
+      };
+      fs.mkdirSync(clauiHome, { recursive: true });
+      fs.mkdirSync(storageDir, { recursive: true });
+      const file = path.join(clauiHome, 'bridge.json');
+      const tmp = `${file}.tmp`;
+      fs.writeFileSync(tmp, JSON.stringify(payload, null, 2));
+      fs.renameSync(tmp, file);
+    } catch {
+      /* config mirroring is best-effort; the runtime falls back to defaults */
+    }
+  }
+
+  /** Model-picker entries for every enabled bridge backend. */
+  modelOptions(): BridgeModelOption[] {
+    const cfg = this.config();
+    const options: BridgeModelOption[] = [];
+
+    if (cfg.get<boolean>('bridge.grok.enabled', false)) {
+      for (const model of cfg.get<string[]>('bridge.grok.models', ['grok-4.5'])) {
+        if (typeof model === 'string' && model.trim()) {
+          options.push({
+            label: `Grok · ${model.trim()}`,
+            value: `${BRIDGE_MODEL_PREFIX}grok/${model.trim()}`,
+          });
+        }
+      }
+    }
+
+    if (cfg.get<boolean>('bridge.antigravity.enabled', false)) {
+      const models = cfg.get<string[]>('bridge.antigravity.models', ['gemini-3-flash-preview']);
+      for (const model of models) {
+        if (typeof model === 'string' && model.trim()) {
+          options.push({
+            label: `Antigravity · ${model.trim()}`,
+            value: `${BRIDGE_MODEL_PREFIX}antigravity/${model.trim()}`,
+          });
+        }
+      }
+    }
+
+    for (const provider of this.openAiProviders()) {
+      const label = provider.label || provider.id;
+      for (const model of provider.models || []) {
+        if (typeof model === 'string' && model.trim()) {
+          options.push({
+            label: `${label} · ${model.trim()}`,
+            value: `${BRIDGE_MODEL_PREFIX}openai/${provider.id}/${model.trim()}`,
+          });
+        }
+      }
+    }
+
+    return options;
+  }
+}

--- a/src/extension/bridge/BridgeProviderService.ts
+++ b/src/extension/bridge/BridgeProviderService.ts
@@ -1,3 +1,4 @@
+import { spawnSync } from 'child_process';
 import * as fs from 'fs';
 import * as os from 'os';
 import * as path from 'path';
@@ -20,6 +21,9 @@ import * as vscode from 'vscode';
  */
 
 export const BRIDGE_MODEL_PREFIX = 'bridge:';
+/** Sentinel picker values that trigger the CLI install flow instead of a
+ *  model switch (e.g. `bridge:install/grok`). */
+export const BRIDGE_INSTALL_PREFIX = 'bridge:install/';
 /** Marker every bridge cliPathOverride contains — used to recognize bridge
  *  tabs in snapshots even across extension updates (the absolute path moves). */
 const BRIDGE_CLI_MARKER = `bridge-runtime${path.sep}cli.js`;
@@ -41,6 +45,10 @@ interface OpenAiProviderSetting {
 
 export function isBridgeModelValue(value: string | null | undefined): boolean {
   return !!value && String(value).startsWith(BRIDGE_MODEL_PREFIX);
+}
+
+export function isBridgeInstallValue(value: string | null | undefined): boolean {
+  return !!value && String(value).startsWith(BRIDGE_INSTALL_PREFIX);
 }
 
 /** Backend segment of a bridge model value ('grok' | 'antigravity' | 'openai/<id>'). */
@@ -83,6 +91,66 @@ export class BridgeProviderService {
 
   private constructor(private readonly context: vscode.ExtensionContext) {}
 
+  /** Cached CLI detection results (reset when bridge settings change). */
+  private cliDetectionCache = new Map<string, boolean>();
+
+  /** True when the configured CLI for a backend actually exists on this
+   *  machine — an absolute path that exists, a known install location, or a
+   *  PATH hit. Lets the feature default ON while only surfacing backends the
+   *  user can actually run (no CLI installed → no picker noise). */
+  private cliDetected(kind: 'grok' | 'antigravity'): boolean {
+    const cached = this.cliDetectionCache.get(kind);
+    if (cached !== undefined) {
+      return cached;
+    }
+    const fallback = kind === 'grok' ? 'grok' : 'agy';
+    const configured = this.config()
+      .get<string>(`bridge.${kind}.cliPath`, fallback)
+      .trim() || fallback;
+
+    let detected = false;
+    if (path.isAbsolute(configured)) {
+      detected = fs.existsSync(configured);
+    } else {
+      // Known global install locations first (cheap fs checks).
+      if (process.platform === 'win32') {
+        if (kind === 'grok' && process.env.APPDATA) {
+          detected = fs.existsSync(
+            path.join(
+              process.env.APPDATA,
+              'npm',
+              'node_modules',
+              '@xai-official',
+              'grok',
+              'node_modules',
+              '@xai-official',
+              'grok-win32-x64',
+              'bin',
+              'grok.exe',
+            ),
+          );
+        }
+        if (kind === 'antigravity' && !detected && process.env.LOCALAPPDATA) {
+          detected = fs.existsSync(
+            path.join(process.env.LOCALAPPDATA, 'agy', 'bin', 'agy.exe'),
+          );
+        }
+      }
+      if (!detected) {
+        // PATH probe (handles .cmd shims on Windows and symlinks elsewhere).
+        const probe = process.platform === 'win32' ? 'where' : 'which';
+        try {
+          const res = spawnSync(probe, [configured], { timeout: 3000, windowsHide: true });
+          detected = res.status === 0;
+        } catch {
+          detected = false;
+        }
+      }
+    }
+    this.cliDetectionCache.set(kind, detected);
+    return detected;
+  }
+
   /** Command string spawned instead of the claude CLI for bridge tabs.
    *  ClaudeProcessManager spawns through a shell, so an embedded quoted path
    *  is safe. Requires `node` on PATH (same class of requirement as the other
@@ -110,6 +178,7 @@ export class BridgeProviderService {
 
   /** Mirror settings into ~/.claui/bridge.json for the bridge runtime. */
   syncConfigFile(): void {
+    this.cliDetectionCache.clear();
     try {
       const cfg = this.config();
       const clauiHome = path.join(os.homedir(), '.claui');
@@ -141,26 +210,45 @@ export class BridgeProviderService {
     const cfg = this.config();
     const options: BridgeModelOption[] = [];
 
-    if (cfg.get<boolean>('bridge.grok.enabled', false)) {
-      for (const model of cfg.get<string[]>('bridge.grok.models', ['grok-4.5'])) {
-        if (typeof model === 'string' && model.trim()) {
-          options.push({
-            label: `Grok · ${model.trim()}`,
-            value: `${BRIDGE_MODEL_PREFIX}grok/${model.trim()}`,
-          });
+    if (cfg.get<boolean>('bridge.grok.enabled', true)) {
+      if (this.cliDetected('grok')) {
+        for (const model of cfg.get<string[]>('bridge.grok.models', ['grok-4.5'])) {
+          if (typeof model === 'string' && model.trim()) {
+            options.push({
+              label: `Grok · ${model.trim()}`,
+              value: `${BRIDGE_MODEL_PREFIX}grok/${model.trim()}`,
+            });
+          }
         }
+      } else {
+        // CLI not installed: offer a one-click install flow right in the picker
+        // for users who have a Grok subscription.
+        options.push({
+          label: '➕ Grok — Install CLI…',
+          value: `${BRIDGE_INSTALL_PREFIX}grok`,
+        });
       }
     }
 
-    if (cfg.get<boolean>('bridge.antigravity.enabled', false)) {
-      const models = cfg.get<string[]>('bridge.antigravity.models', ['gemini-3-flash-preview']);
-      for (const model of models) {
-        if (typeof model === 'string' && model.trim()) {
-          options.push({
-            label: `Antigravity · ${model.trim()}`,
-            value: `${BRIDGE_MODEL_PREFIX}antigravity/${model.trim()}`,
-          });
+    if (cfg.get<boolean>('bridge.antigravity.enabled', true)) {
+      if (this.cliDetected('antigravity')) {
+        const models = cfg.get<string[]>('bridge.antigravity.models', [
+          'gemini-3.6-flash-medium',
+          'gemini-3.1-pro-high',
+        ]);
+        for (const model of models) {
+          if (typeof model === 'string' && model.trim()) {
+            options.push({
+              label: `Antigravity · ${model.trim()}`,
+              value: `${BRIDGE_MODEL_PREFIX}antigravity/${model.trim()}`,
+            });
+          }
         }
+      } else {
+        options.push({
+          label: '➕ Antigravity — Install CLI…',
+          value: `${BRIDGE_INSTALL_PREFIX}antigravity`,
+        });
       }
     }
 
@@ -177,5 +265,47 @@ export class BridgeProviderService {
     }
 
     return options;
+  }
+
+  /** Guided install for a missing provider CLI: primes the official install
+   *  command in an integrated terminal (never auto-executes it) and links the
+   *  docs. Triggered from the "Install CLI…" picker entries. */
+  async startCliInstall(kind: 'grok' | 'antigravity'): Promise<void> {
+    const isWin = process.platform === 'win32';
+    const info =
+      kind === 'grok'
+        ? {
+            title: 'Grok CLI (xAI)',
+            install: 'npm install -g @xai-official/grok',
+            afterInstall: 'run `grok login` to sign in with your xAI subscription',
+            docsUrl: 'https://www.npmjs.com/package/@xai-official/grok',
+          }
+        : {
+            title: 'Antigravity CLI (agy)',
+            install: isWin
+              ? 'curl -fsSL https://antigravity.google/cli/install.cmd -o install.cmd && install.cmd && del install.cmd'
+              : 'curl -fsSL https://antigravity.google/cli/install.sh | bash',
+            afterInstall: 'run `agy` once to sign in with your Google AI subscription',
+            docsUrl: 'https://antigravity.google/docs/cli/install',
+          };
+
+    const choice = await vscode.window.showInformationMessage(
+      `${info.title} is required for these models (you bring your own subscription). Install it now?`,
+      'Install in Terminal',
+      'Open Docs',
+    );
+    if (choice === 'Install in Terminal') {
+      const terminal = vscode.window.createTerminal({ name: `Install ${info.title}` });
+      terminal.show();
+      // Primed but NOT executed — the user reviews and presses Enter.
+      terminal.sendText(info.install, false);
+      void vscode.window.showInformationMessage(
+        `The install command is ready in the terminal — press Enter to run it. Afterwards ${info.afterInstall}, then reload the window to refresh the model picker.`,
+      );
+    } else if (choice === 'Open Docs') {
+      void vscode.env.openExternal(vscode.Uri.parse(info.docsUrl));
+    }
+    // Re-probe on the next picker refresh in case the install completed.
+    this.cliDetectionCache.clear();
   }
 }

--- a/src/extension/extension.ts
+++ b/src/extension/extension.ts
@@ -28,6 +28,7 @@ import { ParticleAcceleratorService } from './particle-accelerator/ParticleAccel
 import { SecretProtectionService } from './secret-protection/SecretProtectionService';
 import { SuperParticleAcceleratorService } from './super-particle-accelerator/SuperParticleAcceleratorService';
 import { WorkspaceAccessGuardService } from './workspace-access-guard/WorkspaceAccessGuardService';
+import { BridgeProviderService } from './bridge/BridgeProviderService';
 
 let tabManager: TabManager;
 let outputChannel: vscode.OutputChannel;
@@ -63,6 +64,11 @@ export function activate(context: vscode.ExtensionContext): void {
   }
 
   log('Extension activating...');
+
+  // Bridge Providers: mirror claudeMirror.bridge.* settings into
+  // ~/.claui/bridge.json for the bundled bridge runtime (Grok / Antigravity /
+  // OpenAI-compatible backends driven through ordinary Claude tabs).
+  BridgeProviderService.init(context);
 
   // Create session store for conversation history persistence
   const sessionStore = new SessionStore(context.globalState);

--- a/src/extension/session/SessionTab.ts
+++ b/src/extension/session/SessionTab.ts
@@ -22,6 +22,12 @@ import type { SessionStore } from './SessionStore';
 import type { ProjectAnalyticsStore } from './ProjectAnalyticsStore';
 import type { PromptHistoryStore } from './PromptHistoryStore';
 import { MessageHandler, type WebviewBridge } from '../webview/MessageHandler';
+import {
+  BridgeProviderService,
+  bridgeBackendKey,
+  isBridgeCliCommand,
+  isBridgeModelValue,
+} from '../bridge/BridgeProviderService';
 import { buildWebviewHtml } from '../webview/WebviewProvider';
 import type { SkillGenService } from '../skillgen/SkillGenService';
 import type { TokenUsageRatioTracker } from './TokenUsageRatioTracker';
@@ -169,6 +175,9 @@ export class SessionTab implements WebviewBridge {
   private teamHadWorkingAgent = false;
   /** Per-tab CLI override (used by Happy provider to spawn `happy` instead of `claude`) */
   private cliPathOverride: string | null = null;
+  /** Bridge Providers: backend key of the active bridge model ('grok',
+   *  'antigravity', 'openai/<id>'), or null when this tab runs real Claude. */
+  private bridgeBackend: string | null = null;
   /** Subscription for VS Code window state changes (focus/blur) */
   private windowStateSubscription: vscode.Disposable | null = null;
   /** Debounced timer for delayed focusInput after window-focus events */
@@ -582,9 +591,37 @@ export class SessionTab implements WebviewBridge {
     const sessionToResume = this.processManager.currentSessionId;
     const atSessionStart = this.messageHandler.isAtSessionStart;
 
+    // Bridge Providers: crossing a provider boundary (claude <-> bridge, or one
+    // bridge backend to another) swaps the CLI override and always starts a
+    // fresh session — a claude session id cannot be resumed by another backend
+    // and vice versa. Same-backend switches keep the session; the bridge
+    // runtime resolves continuity from its own per-session state.
+    const wantsBridge = isBridgeModelValue(model);
+    const hadBridge = isBridgeCliCommand(this.cliPathOverride);
+    const newBackend = wantsBridge ? bridgeBackendKey(model) : null;
+    const backendChanged =
+      wantsBridge && hadBridge && this.bridgeBackend !== null && this.bridgeBackend !== newBackend;
+    const providerBoundaryCrossed = wantsBridge !== hadBridge || backendChanged;
+    if (wantsBridge && !hadBridge) {
+      const bridge = BridgeProviderService.get();
+      if (!bridge) {
+        this.postMessage({ type: 'error', message: 'Bridge Providers service is not available.' });
+        return;
+      }
+      this.cliPathOverride = bridge.cliCommand();
+      this.callbacks.onProviderChanged?.(this.id, 'claude', this.cliPathOverride);
+      this.log(`[Tab ${this.tabNumber}] Bridge provider engaged: ${newBackend}`);
+    } else if (!wantsBridge && hadBridge) {
+      this.cliPathOverride = null;
+      this.callbacks.onProviderChanged?.(this.id, 'claude', null);
+      this.log(`[Tab ${this.tabNumber}] Bridge provider released; back to Claude CLI`);
+    }
+    this.bridgeBackend = newBackend;
+
     // At the beginning of a session (no messages sent yet), restart fresh with the new model
     // rather than resuming, so the session is clean and uses the correct model from the start.
-    if (atSessionStart) {
+    // A provider-boundary crossing forces the same fresh path mid-session.
+    if (atSessionStart || providerBoundaryCrossed) {
       this.log(`[Tab ${this.tabNumber}] Switching model to "${model}" at session start (fresh restart)`);
       this.suppressNextExit = true;
       this.postMessage({ type: 'processBusy', busy: true });

--- a/src/extension/session/TabManager.ts
+++ b/src/extension/session/TabManager.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as path from 'path';
 import * as os from 'os';
 import { SessionTab } from './SessionTab';
+import { BridgeProviderService, isBridgeCliCommand } from '../bridge/BridgeProviderService';
 import { CodexSessionTab } from './CodexSessionTab';
 import { buildSmartSearchPrompt } from './SmartSearchPrompt';
 import { relocateSessionTranscript } from './sessionPathResolver';
@@ -1967,6 +1968,20 @@ export class TabManager {
                   .get<string>('happy.cliPath', '');
                 const chosenPath = livePath || entry.cliPathOverride || 'happy';
                 tab.setCliPathOverride(chosenPath);
+              }
+
+              // Bridge tabs (claude provider + bridge cliPathOverride): recompute
+              // the bridge command from the CURRENT extension install — the
+              // stored absolute path breaks on every extension update.
+              if (
+                entry.provider === 'claude' &&
+                tab instanceof SessionTab &&
+                isBridgeCliCommand(entry.cliPathOverride)
+              ) {
+                const bridge = BridgeProviderService.get();
+                if (bridge) {
+                  tab.setCliPathOverride(bridge.cliCommand());
+                }
               }
 
               // Re-apply the worktree so the restored session spawns in the same

--- a/src/extension/types/webview-messages.ts
+++ b/src/extension/types/webview-messages.ts
@@ -1665,6 +1665,14 @@ export interface DefaultModelHintMessage {
   model: string;
 }
 
+/** Bridge Provider models (Grok / Antigravity / OpenAI-compatible) offered in
+ *  the model picker. Values are namespaced `bridge:<backend>/<model>` and are
+ *  routed to the bundled bridge runtime instead of the claude CLI. */
+export interface BridgeModelOptionsMessage {
+  type: 'bridgeModelOptions';
+  options: { label: string; value: string }[];
+}
+
 export interface ClaudeEffortSettingMessage {
   type: 'claudeEffortSetting';
   effort: ClaudeEffortLevel;
@@ -3035,6 +3043,7 @@ export type ExtensionToWebviewMessage =
   | MessageColorSchemeSettingMessage
   | ModelSettingMessage
   | DefaultModelHintMessage
+  | BridgeModelOptionsMessage
   | ClaudeEffortSettingMessage
   | ClaudeFastModeSettingMessage
   | ProviderSettingMessage

--- a/src/extension/webview/MessageHandler.ts
+++ b/src/extension/webview/MessageHandler.ts
@@ -17,7 +17,11 @@ import type { AchievementService } from '../achievements/AchievementService';
 import type { SkillGenService } from '../skillgen/SkillGenService';
 import { getStoredApiKey, setStoredApiKey, maskApiKey } from '../process/envUtils';
 import { readCodexModelOptions } from '../process/codexModelCache';
-import { BridgeProviderService, isBridgeModelValue } from '../bridge/BridgeProviderService';
+import {
+  BridgeProviderService,
+  isBridgeInstallValue,
+  isBridgeModelValue,
+} from '../bridge/BridgeProviderService';
 import type { TokenUsageRatioTracker } from '../session/TokenUsageRatioTracker';
 import type { DeveloperUsageReporter } from '../usage/DeveloperUsageReporter';
 import type { CheckpointManager } from '../session/CheckpointManager';
@@ -2100,6 +2104,18 @@ export class MessageHandler {
           break;
 
         case 'setModel':
+          // Bridge "Install CLI…" picker entries launch the guided install flow
+          // instead of a model switch; snap the picker back to the tab's model.
+          if (isBridgeInstallValue(msg.model)) {
+            const kind = msg.model.endsWith('antigravity') ? 'antigravity' : 'grok';
+            this.log(`Bridge CLI install flow requested: ${kind}`);
+            void BridgeProviderService.get()?.startCliInstall(kind);
+            this.webview.postMessage({
+              type: 'modelSetting',
+              model: this.webview.getSelectedModel?.() ?? '',
+            });
+            break;
+          }
           this.log(`Setting model to: "${msg.model}"`);
           // Persist as the default for NEW tabs only. This is a global setting,
           // but its change is intentionally NOT broadcast to other open sessions

--- a/src/extension/webview/MessageHandler.ts
+++ b/src/extension/webview/MessageHandler.ts
@@ -17,6 +17,7 @@ import type { AchievementService } from '../achievements/AchievementService';
 import type { SkillGenService } from '../skillgen/SkillGenService';
 import { getStoredApiKey, setStoredApiKey, maskApiKey } from '../process/envUtils';
 import { readCodexModelOptions } from '../process/codexModelCache';
+import { BridgeProviderService, isBridgeModelValue } from '../bridge/BridgeProviderService';
 import type { TokenUsageRatioTracker } from '../session/TokenUsageRatioTracker';
 import type { DeveloperUsageReporter } from '../usage/DeveloperUsageReporter';
 import type { CheckpointManager } from '../session/CheckpointManager';
@@ -2103,7 +2104,11 @@ export class MessageHandler {
           // Persist as the default for NEW tabs only. This is a global setting,
           // but its change is intentionally NOT broadcast to other open sessions
           // (see watchConfigChanges) so a model pick stays local to this session.
-          vscode.workspace.getConfiguration('claudeMirror').update('model', msg.model, true);
+          // Bridge models are deliberately NOT persisted: a new Claude tab must
+          // never inherit `bridge:*` and hand it to the real claude CLI.
+          if (!isBridgeModelValue(msg.model)) {
+            vscode.workspace.getConfiguration('claudeMirror').update('model', msg.model, true);
+          }
           // Confirm the choice to THIS webview only (authoritative echo). Other
           // sessions/windows are not notified, so their pickers are unaffected.
           this.webview.postMessage({ type: 'modelSetting', model: msg.model });
@@ -4009,6 +4014,8 @@ export class MessageHandler {
           // Send the last-resolved Default model so the selector can show the
           // likely model on hover before this session's first turn reports it
           this.sendDefaultModelHint();
+          // Send Bridge Provider models (Grok / Antigravity / OpenAI-compatible)
+          this.sendBridgeModelOptions();
           // Send Claude effort level setting
           this.sendClaudeEffortSetting();
           // Send Claude fast mode setting
@@ -4413,6 +4420,16 @@ export class MessageHandler {
     this.webview.postMessage({
       type: 'codexModelOptions',
       options: readCodexModelOptions((message) => this.log(message)),
+    });
+  }
+
+  /** Push Bridge Provider model options (Grok / Antigravity / OpenAI-compatible)
+   *  so the Model selector can offer them alongside the Claude models. */
+  private sendBridgeModelOptions(): void {
+    const options = BridgeProviderService.get()?.modelOptions() ?? [];
+    this.webview.postMessage({
+      type: 'bridgeModelOptions',
+      options,
     });
   }
 

--- a/src/webview/components/ModelSelector/ModelSelector.tsx
+++ b/src/webview/components/ModelSelector/ModelSelector.tsx
@@ -8,7 +8,14 @@ import { CLAUDE_MODEL_OPTIONS, getClaudeModelLabel } from '../../utils/claudeMod
  * Changing the model live-switches the current session (stop + resume with new model).
  */
 export const ModelSelector: React.FC = () => {
-  const { selectedModel, model, isConnected, lastResolvedDefaultModel, setSelectedModel } = useAppStore();
+  const {
+    selectedModel,
+    model,
+    isConnected,
+    lastResolvedDefaultModel,
+    bridgeModelOptions,
+    setSelectedModel,
+  } = useAppStore();
 
   // "Default" (empty value) means no --model flag is passed and the Claude CLI
   // picks the model itself. Only when Default is the active selection does the
@@ -37,7 +44,10 @@ export const ModelSelector: React.FC = () => {
   const resolvedDefaultLabel = liveDefaultLabel ?? rememberedDefaultLabel;
 
   const modelOptions = useMemo(() => {
-    const base = !selectedModel || CLAUDE_MODEL_OPTIONS.some((opt) => opt.value === selectedModel)
+    const isKnown =
+      CLAUDE_MODEL_OPTIONS.some((opt) => opt.value === selectedModel) ||
+      bridgeModelOptions.some((opt) => opt.value === selectedModel);
+    const base = !selectedModel || isKnown
       ? CLAUDE_MODEL_OPTIONS
       : [
           ...CLAUDE_MODEL_OPTIONS,
@@ -52,7 +62,7 @@ export const ModelSelector: React.FC = () => {
     return base.map((opt) =>
       opt.value === '' ? { ...opt, label: `Default (${resolvedDefaultLabel})` } : opt,
     );
-  }, [selectedModel, resolvedDefaultLabel]);
+  }, [selectedModel, resolvedDefaultLabel, bridgeModelOptions]);
 
   const handleChange = useCallback((e: React.ChangeEvent<HTMLSelectElement>) => {
     const newModel = e.target.value;
@@ -81,11 +91,30 @@ export const ModelSelector: React.FC = () => {
         onChange={handleChange}
         data-tooltip={selectTooltip}
       >
-        {modelOptions.map((opt) => (
-          <option key={opt.value} value={opt.value}>
-            {opt.label}
-          </option>
-        ))}
+        {bridgeModelOptions.length === 0 ? (
+          modelOptions.map((opt) => (
+            <option key={opt.value} value={opt.value}>
+              {opt.label}
+            </option>
+          ))
+        ) : (
+          <>
+            <optgroup label="Claude">
+              {modelOptions.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </optgroup>
+            <optgroup label="Bridge Providers">
+              {bridgeModelOptions.map((opt) => (
+                <option key={opt.value} value={opt.value}>
+                  {opt.label}
+                </option>
+              ))}
+            </optgroup>
+          </>
+        )}
       </select>
       {isConnected && activeModelLabel && (
         <span className="model-selector-active" data-tooltip="Currently active model">

--- a/src/webview/hooks/useClaudeStream.ts
+++ b/src/webview/hooks/useClaudeStream.ts
@@ -41,6 +41,7 @@ export function useClaudeStream(): void {
     setProviderCapabilities,
     setSelectedModel,
     setLastResolvedDefaultModel,
+    setBridgeModelOptions,
     setSelectedClaudeEffort,
     setSelectedClaudeFastMode,
     setSelectedCodexReasoningEffort,
@@ -682,6 +683,11 @@ export function useClaudeStream(): void {
           // Model the CLI last resolved "Default" to; shown on the selector before
           // this session's own system/init reports the live model.
           setLastResolvedDefaultModel(msg.model || null);
+          break;
+
+        case 'bridgeModelOptions':
+          // Bridge Provider models (Grok / Antigravity / OpenAI-compatible)
+          setBridgeModelOptions(msg.options || []);
           break;
 
         case 'claudeEffortSetting':
@@ -1451,6 +1457,7 @@ export function useClaudeStream(): void {
     setProviderCapabilities,
     setSelectedModel,
     setLastResolvedDefaultModel,
+    setBridgeModelOptions,
     setSelectedClaudeEffort,
     setSelectedClaudeFastMode,
     setSelectedCodexReasoningEffort,

--- a/src/webview/state/store.ts
+++ b/src/webview/state/store.ts
@@ -182,6 +182,9 @@ export interface AppState {
   // the extension's globalState. Lets the Model selector show the likely model on
   // hover BEFORE the session's own system/init reports it. null = none known yet.
   lastResolvedDefaultModel: string | null;
+  // Bridge Provider models (Grok / Antigravity / OpenAI-compatible) pushed from
+  // the extension; offered in the model picker alongside the Claude models.
+  bridgeModelOptions: { label: string; value: string }[];
   selectedClaudeEffort: ClaudeEffortLevel;
   selectedClaudeFastMode: boolean;
   selectedCodexReasoningEffort: CodexReasoningEffort;
@@ -778,6 +781,7 @@ export interface AppState {
   setResuming: (resuming: boolean) => void;
   setSelectedModel: (model: string) => void;
   setLastResolvedDefaultModel: (model: string | null) => void;
+  setBridgeModelOptions: (options: { label: string; value: string }[]) => void;
   setSelectedClaudeEffort: (effort: ClaudeEffortLevel) => void;
   setSelectedClaudeFastMode: (fastMode: boolean) => void;
   setSelectedCodexReasoningEffort: (effort: CodexReasoningEffort) => void;
@@ -1184,6 +1188,7 @@ export const useAppStore = create<AppState>((set, get) => ({
   tabKind: 'chat',
   model: null,
   lastResolvedDefaultModel: null,
+  bridgeModelOptions: [],
   selectedProvider: 'claude',
   providerCapabilities: { ...DEFAULT_PROVIDER_CAPABILITIES },
   selectedModel: '',
@@ -2218,6 +2223,8 @@ export const useAppStore = create<AppState>((set, get) => ({
   setSelectedModel: (model) => set({ selectedModel: model }),
 
   setLastResolvedDefaultModel: (model) => set({ lastResolvedDefaultModel: model }),
+
+  setBridgeModelOptions: (options) => set({ bridgeModelOptions: options }),
 
   setSelectedClaudeEffort: (effort) => set({ selectedClaudeEffort: effort }),
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -59,6 +59,37 @@ module.exports = [
     },
     devtool: 'nosources-source-map',
   },
+  // Bridge Providers runtime (Node.js CLI, runs outside VS Code) — spawned
+  // instead of the claude CLI for Grok / Antigravity / OpenAI-compatible tabs.
+  {
+    name: 'bridge-runtime',
+    target: 'node',
+    mode: 'none',
+    entry: {
+      'cli': './src/bridge-runtime/cli.ts',
+    },
+    output: {
+      path: path.resolve(__dirname, 'dist', 'bridge-runtime'),
+      filename: '[name].js',
+      libraryTarget: 'commonjs2',
+    },
+    resolve: {
+      extensions: ['.ts', '.js'],
+    },
+    module: {
+      rules: [
+        {
+          test: /\.ts$/,
+          exclude: /node_modules/,
+          use: 'ts-loader',
+        },
+      ],
+    },
+    optimization: {
+      minimize: false,
+    },
+    devtool: 'nosources-source-map',
+  },
   // Particle Accelerator runtime (Node.js CLI, runs outside VS Code)
   {
     name: 'particle-accelerator-runtime',


### PR DESCRIPTION
## TL;DR (עברית)

מוסיף ל-ClaUi תמיכה מובנית בספקים נוספים דרך טאבים רגילים: **Grok** (דרך ה-CLI הרשמי של xAI ב-ACP), **Antigravity** (דרך `agy` במצב headless), וכל **שרת תואם-OpenAI** (Ollama / LM Studio / llama.cpp / vLLM). הכל באותו בורר מודלים, עם המשכיות שיחה פר-טאב, בלי לגעת בזרימת קלוד הקיימת. כל משתמש מביא את המנוי/CLI שלו; כשה-CLI חסר, הבורר מציע "Install CLI…" עם הפקודה הרשמית מוכנה בטרמינל.

## What this adds

A **Bridge Providers** feature: a bundled runtime (`dist/bridge-runtime/cli.js`) that speaks the exact claude-CLI stream-json protocol towards the extension and routes the conversation to one of three backend families:

| Backend | Transport | Notes |
|---|---|---|
| xAI Grok | Official Grok CLI, `grok agent stdio` (ACP / JSON-RPC) | Streaming text + thinking, tool calls translated to Claude-style `tool_use`/`tool_result` for the timeline |
| Google Antigravity | Official `agy` CLI, headless `-p` mode | Per-tab conversation continuity via `--conversation` (id discovered from the CLI's brain dir); no streaming — answer lands when the turn completes |
| OpenAI-compatible | Direct HTTP, SSE streaming | Ollama / LM Studio / llama.cpp / vLLM / hosted; the bridge owns and replays chat history per session (stateless servers) |

## How it integrates (deliberately minimal)

- **Reuses the existing Happy/remote seam**: a bridge model swaps the tab's `cliPathOverride` to the bundled runtime and restarts through the normal `switchModel` path. No new SessionTab class, no changes to `MessageHandler`'s streaming pipeline.
- **Namespaced model values** — `bridge:grok/<model>`, `bridge:antigravity/<model>`, `bridge:openai/<providerId>/<model>` — shown in a separate `Bridge Providers` optgroup in the ModelSelector.
- **No global-model pollution**: `setModel` never persists `bridge:*` into `claudeMirror.model`, so a new Claude tab can never hand a bridge value to the real claude CLI.
- **Provider-boundary switches are fresh sessions** (a claude session id cannot be resumed by another backend); same-backend switches keep the session. The runtime keeps sticky per-session state under the extension's `globalStorage/bridge-sessions`, so tabs survive window reloads — on `--resume` without `--model` it recovers backend + model + history on its own.
- **Snapshot restore** recomputes the bridge command from the current extension install (the stored absolute path breaks on every extension update).
- **Settings mirror**: the runtime can't read VS Code settings, so `BridgeProviderService` mirrors `claudeMirror.bridge.*` into `~/.claui/bridge.json` on activation and on config change.

## Defaults & discoverability

- Enabled by default, but models appear **only when the matching CLI is detected** (absolute path / known install location / PATH probe, cached).
- When a CLI is missing, the picker shows an **`➕ Install CLI…`** entry instead: it primes the official install command in an integrated terminal (**never auto-executes**) and links the docs. Users without Grok/Antigravity subscriptions who don't want the entries can hide them with `claudeMirror.bridge.<backend>.enabled: false`.
- OpenAI-compatible providers are empty by default (nothing to detect) — users add `{id, label, baseUrl, models}` entries in `claudeMirror.bridge.openaiProviders`.
- **No secrets in settings**: API keys come from `apiKeyEnv` / `apiKeyFile` (plain `apiKey` also accepted but discouraged); local servers like Ollama need none.

## Testing done

- **Protocol E2E against a fake OpenAI-compatible SSE server**: fresh session (init → streamed deltas → assistant → `result/success`), `control_request` ack, and **sticky resume** — second spawn with `--resume` and *no* `--model` recovered backend+model+history (server observed the full replayed transcript). PASS.
- **Live Antigravity E2E** (real `agy`, Google AI subscription): full turn through the bridge, conversation id discovered and bound, second-turn continuity verified. PASS.
- **Grok**: verified through ACP `initialize` + `session/new` (session id + model list returned) with the official CLI; the prompt itself hit xAI's `402 Payment Required` on the test account (subscription credits exhausted), which the bridge surfaces as a clean in-chat error. The translation layer mirrors a production-proven external adapter of the same design.
- Webpack: all six targets compile clean (the 3 pre-existing upstream warnings are untouched).
- Not yet exercised: in-IDE run via `deploy:local` (protocol-level validation only) — happy to iterate on review feedback.

## Future work (out of scope here)

- Cross-provider context handoff (extending `runProviderHandoff` beyond Claude↔Codex).
- Dynamic Grok model list (ACP `session/new` already returns `availableModels`).
- Streaming for Antigravity if/when `agy` exposes a streaming print mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
